### PR TITLE
Adds API_GITHUB_ACCESS_TOKEN. Fix #284.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Build, install and test
         shell: pwsh
+        env:
+          API_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: Invoke-Build test -Configuration Release -File ./firebird-odbc-driver.build.ps1
 
       - name: Upload driver (Windows)


### PR DESCRIPTION
Fix #284 

**Root cause:** `PSFirebird`'s Get-FirebirdReleaseUrl.ps1 calls the GitHub API (`https://api.github.com/repos/FirebirdSQL/firebird/releases`) to find Firebird download URLs. Without authentication, GitHub enforces a 60 req/hour rate limit per IP — easily exceeded in a shared CI environment. The PSFirebird 0.5.0 code already supports authenticated requests via `$env:API_GITHUB_ACCESS_TOKEN`, but the workflow never set that variable.

**Fix:** Added `env: API_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the "Build, install and test" step in build-and-test.yml. `GITHUB_TOKEN` is automatically available in every GitHub Actions run and grants authenticated API access (5000 req/hour), which is well above what the workflow needs.
