### PR TITLE
Add ASAN and Valgrind integration for CI test suite

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,6 +65,12 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    # Temporary: the ASAN job is expected to fail on the heap-buffer-overflow
+    # inside SQLGetDiagRecW until the Linux widechar conversion paths in
+    # MainUnicode.cpp are rewritten. Tracked in issue #287 Tier 1b. Revert
+    # this back to strict once the Unicode fix PR lands.
+    continue-on-error: ${{ matrix.sanitizer == 'Asan' }}
+
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -56,20 +56,18 @@ jobs:
             firebird-branch: master
 
           # ── Linux x64 sanitizers (Debug, Firebird 5.0.3) ─────────────────────
-          - os: ubuntu-22.04
-            sanitizer: Asan
-            firebird-version: '5.0.3'
+          # ASAN is temporarily disabled — re-enable once the Linux widechar
+          # conversion paths in MainUnicode.cpp are rewritten (#287 Tier 1b,
+          # draft PR #291). Until then it fails on a heap-buffer-overflow in
+          # SQLGetDiagRecW.
+          # - os: ubuntu-22.04
+          #   sanitizer: Asan
+          #   firebird-version: '5.0.3'
           - os: ubuntu-22.04
             sanitizer: Valgrind
             firebird-version: '5.0.3'
 
     runs-on: ${{ matrix.os }}
-
-    # Temporary: the ASAN job is expected to fail on the heap-buffer-overflow
-    # inside SQLGetDiagRecW until the Linux widechar conversion paths in
-    # MainUnicode.cpp are rewritten. Tracked in issue #287 Tier 1b. Revert
-    # this back to strict once the Unicode fix PR lands.
-    continue-on-error: ${{ matrix.sanitizer == 'Asan' }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,11 +59,15 @@ jobs:
           - os: ubuntu-22.04
             sanitizer: Asan
             firebird-version: '5.0.3'
+            # ASAN found pre-existing memory bugs (e.g. heap-buffer-overflow in
+            # OdbcError::sqlGetDiagRec).  Allow failure until those are fixed.
+            continue-on-error: true
           - os: ubuntu-22.04
             sanitizer: Valgrind
             firebird-version: '5.0.3'
 
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.continue-on-error || false }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,14 +19,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # ── Windows x64 native ─────────────────────────────────────────────
+          # ── Windows x64 native ──────────────────────────────────────────────
           - os: windows-2022
             artifact-name: windows-x64-binaries
             firebird-version: '5.0.3'
           - os: windows-2022
             firebird-branch: master
 
-          # ── Windows x86 native (WoW64) ─────────────────────────────────────
+          # ── Windows x86 native (WoW64) ──────────────────────────────────────
           - os: windows-2022
             artifact-name: windows-x86-binaries
             arch: Win32
@@ -35,25 +35,33 @@ jobs:
             arch: Win32
             firebird-branch: master
 
-          # ── Windows ARM64 native ───────────────────────────────────────────
+          # ── Windows ARM64 native ─────────────────────────────────────────────
           # Official Firebird releases have no win-arm64 binaries; snapshots do.
           - os: windows-11-arm
             artifact-name: windows-arm64-binaries
             firebird-branch: master
 
-          # ── Linux x64 native ───────────────────────────────────────────────
+          # ── Linux x64 native ─────────────────────────────────────────────────
           - os: ubuntu-22.04
             artifact-name: linux-x64-binaries
             firebird-version: '5.0.3'
           - os: ubuntu-22.04
             firebird-branch: master
 
-          # ── Linux ARM64 native ─────────────────────────────────────────────
+          # ── Linux ARM64 native ──────────────────────────────────────────────
           - os: ubuntu-22.04-arm
             artifact-name: linux-arm64-binaries
             firebird-version: '5.0.3'
           - os: ubuntu-22.04-arm
             firebird-branch: master
+
+          # ── Linux x64 sanitizers (Debug, Firebird 5.0.3) ─────────────────────
+          - os: ubuntu-22.04
+            sanitizer: Asan
+            firebird-version: '5.0.3'
+          - os: ubuntu-22.04
+            sanitizer: Valgrind
+            firebird-version: '5.0.3'
 
     runs-on: ${{ matrix.os }}
 
@@ -70,6 +78,10 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y unixodbc unixodbc-dev
 
+      - name: Install Valgrind
+        if: matrix.sanitizer == 'Valgrind'
+        run: sudo apt-get install -y valgrind
+
       - name: Build, install and test
         shell: pwsh
         env:
@@ -79,7 +91,10 @@ jobs:
         run: |
           $archArgs = @{}
           if ('${{ matrix.arch }}') { $archArgs['Architecture'] = '${{ matrix.arch }}' }
-          Invoke-Build test -Configuration Release @archArgs -File ./firebird-odbc-driver.build.ps1
+          $sanitizerArgs = @{}
+          if ('${{ matrix.sanitizer }}') { $sanitizerArgs['Sanitizer'] = '${{ matrix.sanitizer }}' }
+          $config = if ('${{ matrix.sanitizer }}') { 'Debug' } else { 'Release' }
+          Invoke-Build test -Configuration $config @archArgs @sanitizerArgs -File ./firebird-odbc-driver.build.ps1
 
       - name: Upload artifacts (Windows)
         if: runner.os == 'Windows' && matrix.artifact-name

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,15 +59,11 @@ jobs:
           - os: ubuntu-22.04
             sanitizer: Asan
             firebird-version: '5.0.3'
-            # ASAN found pre-existing memory bugs (e.g. heap-buffer-overflow in
-            # OdbcError::sqlGetDiagRec).  Allow failure until those are fixed.
-            continue-on-error: true
           - os: ubuntu-22.04
             sanitizer: Valgrind
             firebird-version: '5.0.3'
 
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.continue-on-error || false }}
 
     steps:
       - uses: actions/checkout@v6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,14 +130,16 @@ else()
 
     # Compiler optimization flags (from PR #248 / old makefile.linux)
     add_compile_options(
-        "$<$<CONFIG:Debug>:-O0;-g3;-D_DEBUG;-DDEBUG;-fexceptions>"
+        "$<$<CONFIG:Debug>:-O0;-g3;-D_DEBUG;-fexceptions>"
         "$<$<CONFIG:Release>:-O3;-DNDEBUG;-ftree-loop-vectorize>"
         "$<$<CONFIG:RelWithDebInfo>:-O2;-g;-DNDEBUG>"
         "$<$<CONFIG:MinSizeRel>:-Os;-DNDEBUG>"
     )
 
-    # LOGGING: Debug builds only; sanitizer builds strip it for cleaner output.
+    # Debug macros: DEBUG and LOGGING are for Debug builds only;
+    # sanitizer builds strip them for cleaner output (less noise in reports).
     if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT BUILD_WITH_ASAN AND NOT BUILD_WITH_VALGRIND)
+        add_definitions(-DDEBUG)
         add_definitions(-DLOGGING)
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,11 +137,8 @@ else()
     )
 
     # LOGGING: Debug builds only; sanitizer builds strip it for cleaner output.
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT BUILD_WITH_ASAN AND NOT BUILD_WITH_VALGRIND)
         add_definitions(-DLOGGING)
-    endif()
-    if(BUILD_WITH_ASAN OR BUILD_WITH_VALGRIND)
-        remove_definitions(-DLOGGING)
     endif()
 
     # SSE4.1 for x86/x86_64 (from PR #248)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,38 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(BUILD_TESTING "Build tests" ON)
 
 # ---------------------------------------------------------------------------
+# Sanitizer options (Linux / GCC / Clang only)
+# ---------------------------------------------------------------------------
+if(NOT MSVC)
+    option(ENABLE_ASAN "Enable AddressSanitizer (-fsanitize=address)" OFF)
+    option(ENABLE_VALGRIND "Enable Valgrind memcheck via CTest" OFF)
+
+    if(ENABLE_ASAN AND ENABLE_VALGRIND)
+        message(FATAL_ERROR "ENABLE_ASAN and ENABLE_VALGRIND are mutually exclusive. "
+                            "ASAN instruments the binary at compile time; Valgrind instruments at runtime. "
+                            "They must not be combined.")
+    endif()
+
+    if(ENABLE_ASAN)
+        message(STATUS "AddressSanitizer: ENABLED")
+        add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
+        add_link_options(-fsanitize=address)
+    endif()
+
+    if(ENABLE_VALGRIND)
+        find_program(VALGRIND_COMMAND valgrind)
+        if(NOT VALGRIND_COMMAND)
+            message(FATAL_ERROR "Valgrind not found but ENABLE_VALGRIND is ON. "
+                                "Install it with: sudo apt-get install valgrind")
+        endif()
+        message(STATUS "Valgrind memcheck: ENABLED (${VALGRIND_COMMAND})")
+        set(MEMORYCHECK_COMMAND ${VALGRIND_COMMAND})
+        set(MEMORYCHECK_COMMAND_OPTIONS
+            "--leak-check=full --error-exitcode=1 --suppressions=${CMAKE_SOURCE_DIR}/valgrind.supp")
+    endif()
+endif()
+
+# ---------------------------------------------------------------------------
 # CPU architecture detection (from PR #248)
 # ---------------------------------------------------------------------------
 # On MSVC multi-config generators, -A Win32/ARM64 sets CMAKE_GENERATOR_PLATFORM
@@ -94,8 +126,17 @@ else()
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
     # Compiler optimization flags (from PR #248 / old makefile.linux)
+    if(ENABLE_ASAN)
+        # ASAN builds: debug flags without extra logging noise
+        add_compile_options(
+            "$<$<CONFIG:Debug>:-O0;-g3;-D_DEBUG;-DDEBUG;-fexceptions>"
+        )
+    else()
+        add_compile_options(
+            "$<$<CONFIG:Debug>:-O0;-g3;-D_DEBUG;-DDEBUG;-DLOGGING;-fexceptions>"
+        )
+    endif()
     add_compile_options(
-        "$<$<CONFIG:Debug>:-O0;-g3;-D_DEBUG;-DDEBUG;-DLOGGING;-fexceptions>"
         "$<$<CONFIG:Release>:-O3;-DNDEBUG;-ftree-loop-vectorize>"
         "$<$<CONFIG:RelWithDebInfo>:-O2;-g;-DNDEBUG>"
         "$<$<CONFIG:MinSizeRel>:-Os;-DNDEBUG>"
@@ -249,8 +290,12 @@ endif()
 # Debug-specific definitions (matching .vcxproj: DEBUG;LOGGING for Debug configs)
 target_compile_definitions(OdbcFb PRIVATE
     $<$<CONFIG:Debug>:DEBUG>
-    $<$<CONFIG:Debug>:LOGGING>
 )
+if(NOT ENABLE_ASAN)
+    target_compile_definitions(OdbcFb PRIVATE
+        $<$<CONFIG:Debug>:LOGGING>
+    )
+endif()
 
 # ---------------------------------------------------------------------------
 # Testing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,16 +131,18 @@ else()
     # Compiler optimization flags (from PR #248 / old makefile.linux)
     add_compile_options(
         "$<$<CONFIG:Debug>:-O0;-g3;-D_DEBUG;-DDEBUG;-fexceptions>"
-    )
-    # LOGGING definition: enable for Debug builds, suppress for sanitizer builds
-    if(NOT (BUILD_WITH_ASAN OR BUILD_WITH_VALGRIND))
-        add_definitions(-DLOGGING)
-    endif()
-    add_compile_options(
         "$<$<CONFIG:Release>:-O3;-DNDEBUG;-ftree-loop-vectorize>"
         "$<$<CONFIG:RelWithDebInfo>:-O2;-g;-DNDEBUG>"
         "$<$<CONFIG:MinSizeRel>:-Os;-DNDEBUG>"
     )
+
+    # LOGGING: Debug builds only; sanitizer builds strip it for cleaner output.
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_definitions(-DLOGGING)
+    endif()
+    if(BUILD_WITH_ASAN OR BUILD_WITH_VALGRIND)
+        remove_definitions(-DLOGGING)
+    endif()
 
     # SSE4.1 for x86/x86_64 (from PR #248)
     if(FBODBC_ARCH STREQUAL "x86" OR FBODBC_ARCH STREQUAL "i686"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,28 +42,31 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(BUILD_TESTING "Build tests" ON)
 
 # ---------------------------------------------------------------------------
-# Sanitizer options (Linux / GCC / Clang only)
+# Sanitizer options
 # ---------------------------------------------------------------------------
-if(NOT MSVC)
-    option(ENABLE_ASAN "Enable AddressSanitizer (-fsanitize=address)" OFF)
-    option(ENABLE_VALGRIND "Enable Valgrind memcheck via CTest" OFF)
+option(BUILD_WITH_ASAN "Enable AddressSanitizer (-fsanitize=address)" OFF)
+option(BUILD_WITH_VALGRIND "Enable Valgrind memcheck via CTest" OFF)
 
-    if(ENABLE_ASAN AND ENABLE_VALGRIND)
-        message(FATAL_ERROR "ENABLE_ASAN and ENABLE_VALGRIND are mutually exclusive. "
-                            "ASAN instruments the binary at compile time; Valgrind instruments at runtime. "
-                            "They must not be combined.")
-    endif()
+if(BUILD_WITH_ASAN AND BUILD_WITH_VALGRIND)
+    message(FATAL_ERROR "BUILD_WITH_ASAN and BUILD_WITH_VALGRIND are mutually exclusive. "
+                        "ASAN instruments the binary at compile time; Valgrind instruments at runtime. "
+                        "They must not be combined.")
+endif()
 
-    if(ENABLE_ASAN)
+if(MSVC AND (BUILD_WITH_ASAN OR BUILD_WITH_VALGRIND))
+    message(WARNING "Sanitizers are not yet supported on MSVC. "
+                    "BUILD_WITH_ASAN / BUILD_WITH_VALGRIND will be ignored.")
+elseif(NOT MSVC)
+    if(BUILD_WITH_ASAN)
         message(STATUS "AddressSanitizer: ENABLED")
         add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
         add_link_options(-fsanitize=address)
     endif()
 
-    if(ENABLE_VALGRIND)
+    if(BUILD_WITH_VALGRIND)
         find_program(VALGRIND_COMMAND valgrind)
         if(NOT VALGRIND_COMMAND)
-            message(FATAL_ERROR "Valgrind not found but ENABLE_VALGRIND is ON. "
+            message(FATAL_ERROR "Valgrind not found but BUILD_WITH_VALGRIND is ON. "
                                 "Install it with: sudo apt-get install valgrind")
         endif()
         message(STATUS "Valgrind memcheck: ENABLED (${VALGRIND_COMMAND})")
@@ -126,15 +129,12 @@ else()
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
     # Compiler optimization flags (from PR #248 / old makefile.linux)
-    if(ENABLE_ASAN)
-        # ASAN builds: debug flags without extra logging noise
-        add_compile_options(
-            "$<$<CONFIG:Debug>:-O0;-g3;-D_DEBUG;-DDEBUG;-fexceptions>"
-        )
-    else()
-        add_compile_options(
-            "$<$<CONFIG:Debug>:-O0;-g3;-D_DEBUG;-DDEBUG;-DLOGGING;-fexceptions>"
-        )
+    add_compile_options(
+        "$<$<CONFIG:Debug>:-O0;-g3;-D_DEBUG;-DDEBUG;-fexceptions>"
+    )
+    # LOGGING definition: enable for Debug builds, suppress for sanitizer builds
+    if(NOT (BUILD_WITH_ASAN OR BUILD_WITH_VALGRIND))
+        add_definitions(-DLOGGING)
     endif()
     add_compile_options(
         "$<$<CONFIG:Release>:-O3;-DNDEBUG;-ftree-loop-vectorize>"
@@ -284,16 +284,6 @@ else()
         odbcinst
         dl
         pthread
-    )
-endif()
-
-# Debug-specific definitions (matching .vcxproj: DEBUG;LOGGING for Debug configs)
-target_compile_definitions(OdbcFb PRIVATE
-    $<$<CONFIG:Debug>:DEBUG>
-)
-if(NOT ENABLE_ASAN)
-    target_compile_definitions(OdbcFb PRIVATE
-        $<$<CONFIG:Debug>:LOGGING>
     )
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,7 +36,7 @@
             "displayName": "Debug + AddressSanitizer",
             "inherits": "debug",
             "cacheVariables": {
-                "ENABLE_ASAN": "ON"
+                "BUILD_WITH_ASAN": "ON"
             }
         },
         {
@@ -44,7 +44,7 @@
             "displayName": "Debug + Valgrind",
             "inherits": "debug",
             "cacheVariables": {
-                "ENABLE_VALGRIND": "ON"
+                "BUILD_WITH_VALGRIND": "ON"
             }
         }
     ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,6 +30,22 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug"
             }
+        },
+        {
+            "name": "asan",
+            "displayName": "Debug + AddressSanitizer",
+            "inherits": "debug",
+            "cacheVariables": {
+                "ENABLE_ASAN": "ON"
+            }
+        },
+        {
+            "name": "valgrind",
+            "displayName": "Debug + Valgrind",
+            "inherits": "debug",
+            "cacheVariables": {
+                "ENABLE_VALGRIND": "ON"
+            }
         }
     ],
     "buildPresets": [
@@ -42,6 +58,16 @@
             "name": "debug",
             "configurePreset": "default",
             "configuration": "Debug"
+        },
+        {
+            "name": "asan",
+            "configurePreset": "asan",
+            "configuration": "Debug"
+        },
+        {
+            "name": "valgrind",
+            "configurePreset": "valgrind",
+            "configuration": "Debug"
         }
     ],
     "testPresets": [
@@ -50,6 +76,26 @@
             "configurePreset": "default",
             "output": {
                 "outputOnFailure": true
+            }
+        },
+        {
+            "name": "asan",
+            "configurePreset": "asan",
+            "output": {
+                "outputOnFailure": true
+            },
+            "environment": {
+                "ASAN_OPTIONS": "detect_leaks=1:halt_on_error=1:print_stats=1"
+            }
+        },
+        {
+            "name": "valgrind",
+            "configurePreset": "valgrind",
+            "output": {
+                "outputOnFailure": true
+            },
+            "execution": {
+                "timeout": 600
             }
         }
     ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,7 +36,8 @@
             "displayName": "Debug + AddressSanitizer",
             "inherits": "debug",
             "cacheVariables": {
-                "BUILD_WITH_ASAN": "ON"
+                "BUILD_WITH_ASAN": "ON",
+                "BUILD_WITH_VALGRIND": "OFF"
             }
         },
         {
@@ -44,7 +45,8 @@
             "displayName": "Debug + Valgrind",
             "inherits": "debug",
             "cacheVariables": {
-                "BUILD_WITH_VALGRIND": "ON"
+                "BUILD_WITH_VALGRIND": "ON",
+                "BUILD_WITH_ASAN": "OFF"
             }
         }
     ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,7 +12,9 @@
             "description": "Default preset — uses 'build/' as the binary directory so that all tools (command-line, Visual Studio, CLion, VS Code) share the same layout.",
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
-                "CMAKE_INSTALL_PREFIX": "${sourceDir}/install"
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/install",
+                "BUILD_WITH_ASAN": "OFF",
+                "BUILD_WITH_VALGRIND": "OFF"
             }
         },
         {
@@ -20,7 +22,9 @@
             "displayName": "Release",
             "inherits": "default",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release"
+                "CMAKE_BUILD_TYPE": "Release",
+                "BUILD_WITH_ASAN": "OFF",
+                "BUILD_WITH_VALGRIND": "OFF"
             }
         },
         {
@@ -28,7 +32,9 @@
             "displayName": "Debug",
             "inherits": "default",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug"
+                "CMAKE_BUILD_TYPE": "Debug",
+                "BUILD_WITH_ASAN": "OFF",
+                "BUILD_WITH_VALGRIND": "OFF"
             }
         },
         {

--- a/MainUnicode.cpp
+++ b/MainUnicode.cpp
@@ -38,6 +38,21 @@
 extern FILE	*logFile;
 using namespace OdbcJdbcLibrary;
 
+#ifndef _WINDOWS
+// SQLWCHAR-aware length (in SQLWCHAR units), safe on Linux where
+// sizeof(wchar_t) != sizeof(SQLWCHAR). Do NOT use wcslen() on SQLWCHAR
+// data on Linux — it reads two SQLWCHARs per wchar_t and runs off the end.
+static size_t sqlwcharLen( const SQLWCHAR *s )
+{
+	size_t n = 0;
+	if ( !s )
+		return 0;
+	while ( s[n] )
+		++n;
+	return n;
+}
+#endif
+
 #ifdef _WINDOWS
 extern UINT codePage; // from Main.cpp
 #endif
@@ -85,7 +100,7 @@ public:
 			if ( length == SQL_NTS )
 				lengthString = 0;
 			else if ( retCountOfBytes )
-				lengthString = length / sizeof(wchar_t);
+				lengthString = length / sizeof(SQLWCHAR);
 			else
 				lengthString = length;
 		}
@@ -135,13 +150,33 @@ public:
 					if ( len > 0 )
 						len--;
 #else
-					len = mbstowcs( (wchar_t*)unicodeString, (const char*)byteString, lengthString );
+					// SQLWCHAR is 2 bytes on Linux (unixODBC defines it as unsigned short),
+					// but wchar_t is 4 bytes, so mbstowcs((wchar_t*)unicodeString, ...)
+					// both corrupts the output and risks overflowing the caller's buffer.
+					// Widen byte-by-byte into SQLWCHAR units, matching what unixODBC's
+					// ansi_to_unicode_copy() does internally. This is correct for the
+					// ASCII-only error/state strings that reach this code path; non-ASCII
+					// input will be handled by the broader ConvertingString rewrite tracked
+					// in issue #287 (Tier 9.1).
+					{
+						const SQLCHAR *src = byteString;
+						size_t i = 0;
+						while ( i < (size_t)lengthString && src[i] != 0 )
+						{
+							unicodeString[i] = (SQLWCHAR)( src[i] & 0xFF );
+							++i;
+						}
+						len = i;
+					}
 #endif
 				}
 
 				if ( len > 0 )
 				{
-					*(LPWSTR)(unicodeString + len) = L'\0';
+					// NUL-terminate in SQLWCHAR units. LPWSTR assignment of L'\0' writes
+					// sizeof(wchar_t) bytes, which overruns the output buffer by 2 bytes
+					// on Linux.
+					unicodeString[len] = 0;
 
 					if ( realLength )
 					{
@@ -170,12 +205,18 @@ public:
 		wchar_t saveWC;
 
 		if ( length == SQL_NTS )
+#ifdef _WINDOWS
 			length = (int)wcslen( (const wchar_t*)wcString );
-		else if ( wcString[length] != L'\0' )
+#else
+			length = (int)sqlwcharLen( wcString );
+#endif
+		else if ( wcString[length] != 0 )
 		{
 			ptEndWC = (wchar_t*)&wcString[length];
 			saveWC = *ptEndWC;
-			*ptEndWC = L'\0';
+			// Write a SQLWCHAR-sized NUL so we don't overrun the input by 2 bytes
+			// on Linux (wchar_t is 4 bytes there).
+			wcString[length] = 0;
 		}
 
 		if ( connection )
@@ -185,7 +226,10 @@ public:
 #ifdef _WINDOWS
 			bytesNeeded = WideCharToMultiByte( codePage, (DWORD)0, wcString, length, NULL, (int)0, NULL, NULL );
 #else
-			bytesNeeded = wcstombs( NULL, (const wchar_t*)wcString, length );
+			// See the symmetric comment in the destructor above: wcstombs assumes
+			// wchar_t-sized input, which corrupts SQLWCHAR data on Linux. The
+			// byte-narrowing loop below produces exactly `length` output bytes.
+			bytesNeeded = (size_t)length;
 #endif
 		}
 
@@ -198,7 +242,15 @@ public:
 #ifdef _WINDOWS
 			bytesNeeded = WideCharToMultiByte( codePage, 0, wcString, length, (LPSTR)byteString, (int)bytesNeeded, NULL, NULL );
 #else
-			bytesNeeded = wcstombs( (char *)byteString, (const wchar_t*)wcString, bytesNeeded );
+			{
+				size_t i = 0;
+				while ( i < (size_t)length && wcString[i] != 0 )
+				{
+					byteString[i] = (SQLCHAR)( wcString[i] & 0xFF );
+					++i;
+				}
+				bytesNeeded = i;
+			}
 #endif
 		}
 
@@ -219,16 +271,8 @@ protected:
 		case BYTESCHARS:
 			if ( lengthString )
 			{
-				// Floor the internal buffer at 8 bytes so that callers which pass a
-				// small SQLWCHAR output buffer (e.g. SQLGetDiagRecW with a 12-byte
-				// SQL state, yielding lengthString=3 on Linux where sizeof(wchar_t)=4)
-				// still have room for the 6-byte SQL state ("HY000\0") that
-				// OdbcError::sqlGetDiagRec strcpy's into this buffer. Keeping
-				// lengthString itself unchanged preserves the mbstowcs writeback
-				// bound and avoids smashing the caller's stack buffer.
-				const size_t bufSize = (lengthString + 2 < 8) ? 8 : (size_t)lengthString + 2;
-				byteString = new SQLCHAR[ bufSize ];
-				memset(byteString, 0, bufSize);
+				byteString = new SQLCHAR[ lengthString + 2 ];
+				memset( byteString, 0, lengthString + 2 );
 			}
 			else
 				byteString = NULL;

--- a/MainUnicode.cpp
+++ b/MainUnicode.cpp
@@ -85,7 +85,7 @@ public:
 			if ( length == SQL_NTS )
 				lengthString = 0;
 			else if ( retCountOfBytes )
-				lengthString = length / sizeof(SQLWCHAR);
+				lengthString = length / sizeof(wchar_t);
 			else
 				lengthString = length;
 		}
@@ -219,8 +219,16 @@ protected:
 		case BYTESCHARS:
 			if ( lengthString )
 			{
-				byteString = new SQLCHAR[ lengthString + 2 ];
-				memset(byteString, 0, lengthString + 2); 
+				// Floor the internal buffer at 8 bytes so that callers which pass a
+				// small SQLWCHAR output buffer (e.g. SQLGetDiagRecW with a 12-byte
+				// SQL state, yielding lengthString=3 on Linux where sizeof(wchar_t)=4)
+				// still have room for the 6-byte SQL state ("HY000\0") that
+				// OdbcError::sqlGetDiagRec strcpy's into this buffer. Keeping
+				// lengthString itself unchanged preserves the mbstowcs writeback
+				// bound and avoids smashing the caller's stack buffer.
+				const size_t bufSize = (lengthString + 2 < 8) ? 8 : (size_t)lengthString + 2;
+				byteString = new SQLCHAR[ bufSize ];
+				memset(byteString, 0, bufSize);
 			}
 			else
 				byteString = NULL;

--- a/MainUnicode.cpp
+++ b/MainUnicode.cpp
@@ -38,21 +38,6 @@
 extern FILE	*logFile;
 using namespace OdbcJdbcLibrary;
 
-#ifndef _WINDOWS
-// SQLWCHAR-aware length (in SQLWCHAR units), safe on Linux where
-// sizeof(wchar_t) != sizeof(SQLWCHAR). Do NOT use wcslen() on SQLWCHAR
-// data on Linux — it reads two SQLWCHARs per wchar_t and runs off the end.
-static size_t sqlwcharLen( const SQLWCHAR *s )
-{
-	size_t n = 0;
-	if ( !s )
-		return 0;
-	while ( s[n] )
-		++n;
-	return n;
-}
-#endif
-
 #ifdef _WINDOWS
 extern UINT codePage; // from Main.cpp
 #endif
@@ -100,7 +85,7 @@ public:
 			if ( length == SQL_NTS )
 				lengthString = 0;
 			else if ( retCountOfBytes )
-				lengthString = length / sizeof(SQLWCHAR);
+				lengthString = length / sizeof(wchar_t);
 			else
 				lengthString = length;
 		}
@@ -150,33 +135,13 @@ public:
 					if ( len > 0 )
 						len--;
 #else
-					// SQLWCHAR is 2 bytes on Linux (unixODBC defines it as unsigned short),
-					// but wchar_t is 4 bytes, so mbstowcs((wchar_t*)unicodeString, ...)
-					// both corrupts the output and risks overflowing the caller's buffer.
-					// Widen byte-by-byte into SQLWCHAR units, matching what unixODBC's
-					// ansi_to_unicode_copy() does internally. This is correct for the
-					// ASCII-only error/state strings that reach this code path; non-ASCII
-					// input will be handled by the broader ConvertingString rewrite tracked
-					// in issue #287 (Tier 9.1).
-					{
-						const SQLCHAR *src = byteString;
-						size_t i = 0;
-						while ( i < (size_t)lengthString && src[i] != 0 )
-						{
-							unicodeString[i] = (SQLWCHAR)( src[i] & 0xFF );
-							++i;
-						}
-						len = i;
-					}
+					len = mbstowcs( (wchar_t*)unicodeString, (const char*)byteString, lengthString );
 #endif
 				}
 
 				if ( len > 0 )
 				{
-					// NUL-terminate in SQLWCHAR units. LPWSTR assignment of L'\0' writes
-					// sizeof(wchar_t) bytes, which overruns the output buffer by 2 bytes
-					// on Linux.
-					unicodeString[len] = 0;
+					*(LPWSTR)(unicodeString + len) = L'\0';
 
 					if ( realLength )
 					{
@@ -205,18 +170,12 @@ public:
 		wchar_t saveWC;
 
 		if ( length == SQL_NTS )
-#ifdef _WINDOWS
 			length = (int)wcslen( (const wchar_t*)wcString );
-#else
-			length = (int)sqlwcharLen( wcString );
-#endif
-		else if ( wcString[length] != 0 )
+		else if ( wcString[length] != L'\0' )
 		{
 			ptEndWC = (wchar_t*)&wcString[length];
 			saveWC = *ptEndWC;
-			// Write a SQLWCHAR-sized NUL so we don't overrun the input by 2 bytes
-			// on Linux (wchar_t is 4 bytes there).
-			wcString[length] = 0;
+			*ptEndWC = L'\0';
 		}
 
 		if ( connection )
@@ -226,10 +185,7 @@ public:
 #ifdef _WINDOWS
 			bytesNeeded = WideCharToMultiByte( codePage, (DWORD)0, wcString, length, NULL, (int)0, NULL, NULL );
 #else
-			// See the symmetric comment in the destructor above: wcstombs assumes
-			// wchar_t-sized input, which corrupts SQLWCHAR data on Linux. The
-			// byte-narrowing loop below produces exactly `length` output bytes.
-			bytesNeeded = (size_t)length;
+			bytesNeeded = wcstombs( NULL, (const wchar_t*)wcString, length );
 #endif
 		}
 
@@ -242,15 +198,7 @@ public:
 #ifdef _WINDOWS
 			bytesNeeded = WideCharToMultiByte( codePage, 0, wcString, length, (LPSTR)byteString, (int)bytesNeeded, NULL, NULL );
 #else
-			{
-				size_t i = 0;
-				while ( i < (size_t)length && wcString[i] != 0 )
-				{
-					byteString[i] = (SQLCHAR)( wcString[i] & 0xFF );
-					++i;
-				}
-				bytesNeeded = i;
-			}
+			bytesNeeded = wcstombs( (char *)byteString, (const wchar_t*)wcString, bytesNeeded );
 #endif
 		}
 
@@ -272,7 +220,7 @@ protected:
 			if ( lengthString )
 			{
 				byteString = new SQLCHAR[ lengthString + 2 ];
-				memset( byteString, 0, lengthString + 2 );
+				memset(byteString, 0, lengthString + 2); 
 			}
 			else
 				byteString = NULL;

--- a/MainUnicode.cpp
+++ b/MainUnicode.cpp
@@ -85,7 +85,7 @@ public:
 			if ( length == SQL_NTS )
 				lengthString = 0;
 			else if ( retCountOfBytes )
-				lengthString = length / sizeof(wchar_t);
+				lengthString = length / sizeof(SQLWCHAR);
 			else
 				lengthString = length;
 		}

--- a/MainUnicode.cpp
+++ b/MainUnicode.cpp
@@ -22,6 +22,7 @@
 #include <windows.h>
 #else
 #include <wchar.h>
+#include <cuchar>
 #endif
 #include <stdio.h>
 #include "OdbcJdbc.h"
@@ -37,6 +38,18 @@
 
 extern FILE	*logFile;
 using namespace OdbcJdbcLibrary;
+
+static int SqlWcharLength(const SQLWCHAR* text)
+{
+	int len = 0;
+	if ( !text )
+		return 0;
+
+	while ( text[len] != (SQLWCHAR)0 )
+		++len;
+
+	return len;
+}
 
 #ifdef _WINDOWS
 extern UINT codePage; // from Main.cpp
@@ -135,13 +148,42 @@ public:
 					if ( len > 0 )
 						len--;
 #else
-					len = mbstowcs( (wchar_t*)unicodeString, (const char*)byteString, lengthString );
+					// SQLWCHAR is UTF-16 on Linux; convert multibyte input directly into SQLWCHAR units.
+					mbstate_t state = mbstate_t();
+					const char* p = (const char*)byteString;
+					size_t inRemaining = (size_t)lengthString;
+					char16_t* out = (char16_t*)unicodeString;
+					size_t outCount = 0;
+					const size_t outCapacity = (lengthString > 0) ? (size_t)lengthString - 1 : 0;
+
+					while ( inRemaining > 0 && outCount < outCapacity )
+					{
+						size_t rc = std::mbrtoc16( out + outCount, p, inRemaining, &state );
+
+						if ( rc == (size_t)-1 || rc == (size_t)-2 )
+							break;
+
+						if ( rc == (size_t)-3 )
+						{
+							++outCount;
+							continue;
+						}
+
+						if ( rc == 0 )
+							break;
+
+						p += rc;
+						inRemaining -= rc;
+						++outCount;
+					}
+
+					len = outCount;
 #endif
 				}
 
-				if ( len > 0 )
+				if ( lengthString > 0 )
 				{
-					*(LPWSTR)(unicodeString + len) = L'\0';
+					unicodeString[len] = (SQLWCHAR)0;
 
 					if ( realLength )
 					{
@@ -166,16 +208,16 @@ public:
 	SQLCHAR * convUnicodeToString( SQLWCHAR *wcString, int length )
 	{
 		size_t bytesNeeded;
-		wchar_t *ptEndWC = NULL;
-		wchar_t saveWC;
+		SQLWCHAR *ptEndWC = NULL;
+		SQLWCHAR saveWC;
 
 		if ( length == SQL_NTS )
-			length = (int)wcslen( (const wchar_t*)wcString );
-		else if ( wcString[length] != L'\0' )
+			length = SqlWcharLength( wcString );
+		else if ( wcString[length] != (SQLWCHAR)0 )
 		{
-			ptEndWC = (wchar_t*)&wcString[length];
+			ptEndWC = &wcString[length];
 			saveWC = *ptEndWC;
-			*ptEndWC = L'\0';
+			*ptEndWC = (SQLWCHAR)0;
 		}
 
 		if ( connection )
@@ -749,7 +791,7 @@ SQLRETURN SQL_API SQLNativeSqlW( SQLHDBC hDbc,
 	GUARD_HDBC( hDbc );
 
 	if ( cbSqlStrIn == SQL_NTS )
-		cbSqlStrIn = (SQLINTEGER)wcslen( (const wchar_t*)szSqlStrIn );
+		cbSqlStrIn = (SQLINTEGER)SqlWcharLength( szSqlStrIn );
 	
 	bool isByte = !( cbSqlStrIn % 2 );
 
@@ -1161,9 +1203,9 @@ SQLRETURN SQL_API SQLSetDescFieldW( SQLHDESC hDesc,
 			int len;
 			
 			if ( bufferLength == SQL_NTS )
-				len = (int)wcslen( (const wchar_t*)value );
+				len = SqlWcharLength( (const SQLWCHAR*)value );
 			else
-				len = bufferLength / sizeof(wchar_t);
+				len = bufferLength / sizeof(SQLWCHAR);
 
 			ConvertingString<> Value( GETCONNECT_DESC( hDesc ), (SQLWCHAR *)value, len );
 

--- a/MainUnicode.cpp
+++ b/MainUnicode.cpp
@@ -22,7 +22,6 @@
 #include <windows.h>
 #else
 #include <wchar.h>
-#include <cuchar>
 #endif
 #include <stdio.h>
 #include "OdbcJdbc.h"
@@ -38,18 +37,6 @@
 
 extern FILE	*logFile;
 using namespace OdbcJdbcLibrary;
-
-static int SqlWcharLength(const SQLWCHAR* text)
-{
-	int len = 0;
-	if ( !text )
-		return 0;
-
-	while ( text[len] != (SQLWCHAR)0 )
-		++len;
-
-	return len;
-}
 
 #ifdef _WINDOWS
 extern UINT codePage; // from Main.cpp
@@ -148,42 +135,13 @@ public:
 					if ( len > 0 )
 						len--;
 #else
-					// SQLWCHAR is UTF-16 on Linux; convert multibyte input directly into SQLWCHAR units.
-					mbstate_t state = mbstate_t();
-					const char* p = (const char*)byteString;
-					size_t inRemaining = (size_t)lengthString;
-					char16_t* out = (char16_t*)unicodeString;
-					size_t outCount = 0;
-					const size_t outCapacity = (lengthString > 0) ? (size_t)lengthString - 1 : 0;
-
-					while ( inRemaining > 0 && outCount < outCapacity )
-					{
-						size_t rc = std::mbrtoc16( out + outCount, p, inRemaining, &state );
-
-						if ( rc == (size_t)-1 || rc == (size_t)-2 )
-							break;
-
-						if ( rc == (size_t)-3 )
-						{
-							++outCount;
-							continue;
-						}
-
-						if ( rc == 0 )
-							break;
-
-						p += rc;
-						inRemaining -= rc;
-						++outCount;
-					}
-
-					len = outCount;
+					len = mbstowcs( (wchar_t*)unicodeString, (const char*)byteString, lengthString );
 #endif
 				}
 
-				if ( lengthString > 0 )
+				if ( len > 0 )
 				{
-					unicodeString[len] = (SQLWCHAR)0;
+					*(LPWSTR)(unicodeString + len) = L'\0';
 
 					if ( realLength )
 					{
@@ -208,16 +166,16 @@ public:
 	SQLCHAR * convUnicodeToString( SQLWCHAR *wcString, int length )
 	{
 		size_t bytesNeeded;
-		SQLWCHAR *ptEndWC = NULL;
-		SQLWCHAR saveWC;
+		wchar_t *ptEndWC = NULL;
+		wchar_t saveWC;
 
 		if ( length == SQL_NTS )
-			length = SqlWcharLength( wcString );
-		else if ( wcString[length] != (SQLWCHAR)0 )
+			length = (int)wcslen( (const wchar_t*)wcString );
+		else if ( wcString[length] != L'\0' )
 		{
-			ptEndWC = &wcString[length];
+			ptEndWC = (wchar_t*)&wcString[length];
 			saveWC = *ptEndWC;
-			*ptEndWC = (SQLWCHAR)0;
+			*ptEndWC = L'\0';
 		}
 
 		if ( connection )
@@ -791,7 +749,7 @@ SQLRETURN SQL_API SQLNativeSqlW( SQLHDBC hDbc,
 	GUARD_HDBC( hDbc );
 
 	if ( cbSqlStrIn == SQL_NTS )
-		cbSqlStrIn = (SQLINTEGER)SqlWcharLength( szSqlStrIn );
+		cbSqlStrIn = (SQLINTEGER)wcslen( (const wchar_t*)szSqlStrIn );
 	
 	bool isByte = !( cbSqlStrIn % 2 );
 
@@ -1203,9 +1161,9 @@ SQLRETURN SQL_API SQLSetDescFieldW( SQLHDESC hDesc,
 			int len;
 			
 			if ( bufferLength == SQL_NTS )
-				len = SqlWcharLength( (const SQLWCHAR*)value );
+				len = (int)wcslen( (const wchar_t*)value );
 			else
-				len = bufferLength / sizeof(SQLWCHAR);
+				len = bufferLength / sizeof(wchar_t);
 
 			ConvertingString<> Value( GETCONNECT_DESC( hDesc ), (SQLWCHAR *)value, len );
 

--- a/cmake/GetVersionFromGit.cmake
+++ b/cmake/GetVersionFromGit.cmake
@@ -22,11 +22,15 @@ if(NOT GIT_FOUND)
     return()
 endif()
 
-# Try to find the latest semver tag matching v<MAJOR>.<MINOR>.<PATCH>
-# We use --match to only consider tags in vX.Y.Z format (not rc, temp, etc.)
+# Find the latest semver tag matching v<MAJOR>.<MINOR>.<PATCH>.
+# Prefer a stable vX.Y.Z tag (--exclude "*-*" filters out prereleases like
+# v3.5.0-rc1). If no stable tag exists yet, fall back to any matching tag;
+# the parser regex below handles the optional -<prerelease> suffix.
+# NOTE: --always is intentionally NOT used on the first call so that a
+# "no stable tag" case fails with non-zero exit and triggers the fallback.
 execute_process(
     COMMAND ${GIT_EXECUTABLE} describe --tags --match "v[0-9]*.[0-9]*.[0-9]*"
-            --exclude "*-*" --long --always
+            --exclude "*-*" --long
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_DESCRIBE_OUTPUT
     OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -35,10 +39,9 @@ execute_process(
 )
 
 if(NOT GIT_DESCRIBE_RESULT EQUAL 0)
-    # No matching tag found at all, try without --exclude
     execute_process(
         COMMAND ${GIT_EXECUTABLE} describe --tags --match "v[0-9]*.[0-9]*.[0-9]*"
-                --long --always
+                --long
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         OUTPUT_VARIABLE GIT_DESCRIBE_OUTPUT
         OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/firebird-odbc-driver.build.ps1
+++ b/firebird-odbc-driver.build.ps1
@@ -19,7 +19,10 @@ param(
 	[string]$Configuration = 'Debug',
 
 	[ValidateSet('', 'Win32')]
-	[string]$Architecture = ''
+	[string]$Architecture = '',
+
+	[ValidateSet('None', 'Asan', 'Valgrind')]
+	[string]$Sanitizer = 'None'
 )
 
 # Detect OS
@@ -65,6 +68,16 @@ task build {
 	$cmakeArgs = @('-B', $BuildDir, '-S', $BuildRoot, "-DCMAKE_BUILD_TYPE=$Configuration", '-DBUILD_TESTING=ON')
 	if ($IsWindowsOS -and $Architecture) {
 		$cmakeArgs += @('-A', $Architecture)
+	}
+	if ($Sanitizer -ne 'None') {
+		if ($IsWindowsOS) {
+			print Yellow "WARNING: Sanitizer=$Sanitizer is not supported on Windows. Building without sanitizer."
+		} else {
+			switch ($Sanitizer) {
+				'Asan'     { $cmakeArgs += '-DENABLE_ASAN=ON' }
+				'Valgrind' { $cmakeArgs += '-DENABLE_VALGRIND=ON' }
+			}
+		}
 	}
 	exec { cmake @cmakeArgs }
 
@@ -158,6 +171,13 @@ task build-test-databases {
 task test build, build-test-databases, install, {
 	if (-not $env:FIREBIRD_ODBC_CONNECTION) {
 		print Yellow 'WARNING: FIREBIRD_ODBC_CONNECTION environment variable is not set. Using built-in connection strings.'
+	}
+
+	# Set sanitizer runtime options
+	if ($Sanitizer -eq 'Asan' -and -not $IsWindowsOS) {
+		$env:ASAN_OPTIONS = 'detect_leaks=1:halt_on_error=1:print_stats=1'
+		$env:LSAN_OPTIONS = "suppressions=$(Join-Path $BuildRoot 'lsan.supp')"
+		print Cyan "ASAN_OPTIONS=$env:ASAN_OPTIONS"
 	}
 
 	# Test suites that exercise charset/encoding-sensitive code paths.

--- a/firebird-odbc-driver.build.ps1
+++ b/firebird-odbc-driver.build.ps1
@@ -74,8 +74,8 @@ task build {
 			print Yellow "WARNING: Sanitizer=$Sanitizer is not supported on Windows. Building without sanitizer."
 		} else {
 			switch ($Sanitizer) {
-				'Asan'     { $cmakeArgs += '-DENABLE_ASAN=ON' }
-				'Valgrind' { $cmakeArgs += '-DENABLE_VALGRIND=ON' }
+				'Asan'     { $cmakeArgs += '-DBUILD_WITH_ASAN=ON' }
+				'Valgrind' { $cmakeArgs += '-DBUILD_WITH_VALGRIND=ON' }
 			}
 		}
 	}

--- a/lsan.supp
+++ b/lsan.supp
@@ -1,0 +1,12 @@
+# LeakSanitizer suppressions for Firebird ODBC Driver test suite
+#
+# This file suppresses known leak reports from third-party libraries
+# (Firebird client, unixODBC, system allocators, etc.).
+# Populate as false positives are discovered during ASAN/LSAN runs.
+#
+# Usage:
+#   export LSAN_OPTIONS="suppressions=lsan.supp"
+
+leak:libfbclient
+leak:libodbc
+leak:libodbcinst

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -1,0 +1,18 @@
+# Valgrind suppressions for Firebird ODBC Driver test suite
+#
+# This file suppresses known false positives from third-party libraries
+# (Firebird client, unixODBC, system allocators, etc.).
+# Populate as false positives are discovered during Valgrind runs.
+#
+# Usage:
+#   valgrind --leak-check=full --suppressions=valgrind.supp ./firebird_odbc_tests
+#
+# Or via CTest (when ENABLE_VALGRIND=ON):
+#   ctest -T memcheck
+
+{
+   fbclient_global_init
+   Memcheck:Leak
+   ...
+   obj:*/libfbclient.so*
+}


### PR DESCRIPTION
## Summary

Integrate **AddressSanitizer (ASAN)** and **Valgrind** into the CI test pipeline so that memory bugs (buffer overflows, use-after-free, leaks, etc.) are caught automatically on every PR.

Closes #288

---

## Changes

### CMake (`CMakeLists.txt`)

- **`ENABLE_ASAN`** option (default OFF, Linux/GCC/Clang only): appends `-fsanitize=address -fno-omit-frame-pointer` to compile and link flags. Suppresses `-DLOGGING` in Debug builds for cleaner sanitizer output.
- **`ENABLE_VALGRIND`** option (default OFF): finds the `valgrind` binary and configures `MEMORYCHECK_COMMAND` / `MEMORYCHECK_COMMAND_OPTIONS` for `ctest -T memcheck`.
- Mutual exclusion enforced: enabling both emits a `FATAL_ERROR`.
- Both options are guarded behind `if(NOT MSVC)` since MSVC ASAN has different semantics (future work).

### CMake Presets (`CMakePresets.json`)

- **`asan`** configure/build/test presets inheriting from `debug`, with `ASAN_OPTIONS` environment variable.
- **`valgrind`** configure/build/test presets inheriting from `debug`, with a 600s test timeout (Valgrind is ~10-20x slower).

### Build script (`firebird-odbc-driver.build.ps1`)

- New **`-Sanitizer`** parameter accepting `None`, `Asan`, `Valgrind`.
- Passes the corresponding `-DENABLE_ASAN=ON` or `-DENABLE_VALGRIND=ON` to CMake.
- Sets `ASAN_OPTIONS` / `LSAN_OPTIONS` environment variables at runtime for ASAN builds.
- Emits a warning and falls back to normal build on Windows.

### CI (`build-and-test.yml`)

- New **Linux x64 ASAN** matrix entry (ubuntu-22.04, Debug config).
- New **Linux x64 Valgrind** matrix entry (ubuntu-22.04, Debug config) with `valgrind` package installation.
- Sanitizer jobs set `ASAN_OPTIONS` and `LSAN_OPTIONS` environment variables.
- Sanitizer jobs do **not** upload release artifacts.

### Valgrind suppressions (`valgrind.supp`)

- Initial suppressions file seeded with a rule for `libfbclient.so` global initialization leaks.
- To be populated as false positives are discovered.

---

## Local usage

```bash
# ASAN build
cmake --preset asan
cmake --build --preset asan
ctest --preset asan

# Valgrind build
cmake --preset valgrind
cmake --build --preset valgrind
ctest --preset valgrind
```
