### PR TITLE
Fix SIGSEGV in SQLCopyDesc when source descriptor is empty

### DIFF
--- a/OdbcDesc.cpp
+++ b/OdbcDesc.cpp
@@ -210,7 +210,8 @@ SQLRETURN OdbcDesc::operator =(OdbcDesc &sour)
 
 	for ( int n = 0 ; n <= headCount ; n++ )
 	{
-		DescRecord *srcrec = sour.records[n];
+		// sour.records is NULL for an empty source — guard like the other loops in this file.
+		DescRecord *srcrec = sour.records ? sour.records[n] : NULL;
 		DescRecord &rec = *getDescRecord ( n );
 
 		if ( srcrec )

--- a/tests/test_phase7_crusher_fixes.cpp
+++ b/tests/test_phase7_crusher_fixes.cpp
@@ -12,7 +12,6 @@
 class CopyDescCrashTest : public OdbcConnectedTest {};
 
 TEST_F(CopyDescCrashTest, CopyEmptyARDDoesNotCrash) {
-    GTEST_SKIP() << "Requires Phase 7: ODBC Crusher-identified bug fixes (not yet merged)";
     // Allocate two statements with no bindings (empty ARDs)
     SQLHSTMT stmt1 = AllocExtraStmt();
     SQLHSTMT stmt2 = AllocExtraStmt();
@@ -49,7 +48,6 @@ TEST_F(CopyDescCrashTest, CopyEmptyARDDoesNotCrash) {
 }
 
 TEST_F(CopyDescCrashTest, CopyEmptyToExplicitDescriptor) {
-    GTEST_SKIP() << "Requires Phase 7: ODBC Crusher-identified bug fixes (not yet merged)";
     // Allocate an explicit descriptor
     SQLHDESC hExplicit = SQL_NULL_HDESC;
     SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DESC, hDbc, &hExplicit);
@@ -70,7 +68,6 @@ TEST_F(CopyDescCrashTest, CopyEmptyToExplicitDescriptor) {
 }
 
 TEST_F(CopyDescCrashTest, CopyPopulatedThenEmpty) {
-    GTEST_SKIP() << "Requires Phase 7: ODBC Crusher-identified bug fixes (not yet merged)";
     // First, populate an explicit descriptor by copying a populated ARD
     SQLINTEGER val = 0;
     SQLLEN ind = 0;


### PR DESCRIPTION
## Summary

`SQLCopyDesc` crashed with SIGSEGV (Linux) / access violation 0xC0000005 (Windows) when the source descriptor had no records — the typical case when the application has fetched an implicit ARD without binding any columns, or freshly allocated an explicit descriptor.

Reproducer:

```c
SQLHSTMT s1, s2;
SQLAllocHandle(SQL_HANDLE_STMT, hDbc, &s1);
SQLAllocHandle(SQL_HANDLE_STMT, hDbc, &s2);

SQLHDESC ard1, ard2;
SQLGetStmtAttr(s1, SQL_ATTR_APP_ROW_DESC, &ard1, 0, NULL);
SQLGetStmtAttr(s2, SQL_ATTR_APP_ROW_DESC, &ard2, 0, NULL);

SQLCopyDesc(ard1, ard2);   // segfaults
```

Caught by [odbc-crusher](https://github.com/fdcastel/odbc-crusher) `v3.5.0-rc1` stress-test (`test_copy_desc` in the Descriptor Tests category — the run hung on a corrupted DM after the SEGV, holding the runner for 47 minutes before being cancelled).

## Root cause

`OdbcDesc::operator=` (the function `SQLCopyDesc` calls into) iterated `sour.records[n]` without first checking that `sour.records` was non-NULL:

```cpp
for ( int n = 0 ; n <= headCount ; n++ )
{
    DescRecord *srcrec = sour.records[n];   // ← deref before null-check
    ...
    if ( srcrec ) { ... }                   // null-check is too late
}
```

`sour.records` is `NULL` for any descriptor that has never had records allocated — implicit ARDs/APDs of statements with no `SQLBindCol`/`SQLBindParameter` calls, or freshly-allocated explicit descriptors. For an empty source `headCount == 0`, the loop runs once with `n = 0`, dereferences `NULL[0]`, crash.

Every other loop in `OdbcDesc.cpp` already guards `if (records)` (lines 104, 119, 148, 162, 181). This one was missing the guard — fixed by inlining the same check on the access.

## Tests

The Phase 7 regression suite (`tests/test_phase7_crusher_fixes.cpp`) already shipped tests for this exact crash — its inline comment at lines 33-34 documents the failure mode word-for-word. The tests were `GTEST_SKIP`'d pending the fix.

This PR un-skips the three tests that the null-guard alone enables:

- `CopyDescCrashTest.CopyEmptyARDDoesNotCrash`
- `CopyDescCrashTest.CopyEmptyToExplicitDescriptor`
- `CopyDescCrashTest.CopyPopulatedThenEmpty`

The four `SetDescCount*` tests in the same file remain skipped — they exercise a separate Phase 7 issue (`SQLSetDescField(SQL_DESC_COUNT)` not allocating the records array) that needs a different fix and is out of scope here.

## Verification

- **CI** — all 10 matrix jobs green (Windows x64 / x86 / ARM64, Linux x64 / ARM64, plus Valgrind, against both Firebird 5.0.3 and Firebird master): https://github.com/fdcastel/firebird-odbc-driver/actions/runs/25024458735

## Test plan

- [x] Three previously-`SKIP`'d regression tests now run and pass across the full CI matrix
- [x] All other tests still pass — no regressions
- [x] odbc-crusher v3.5.0-rc1 against the patched .so completes cleanly: Descriptor Tests now reports **5 passed** (was 1 DRIVER CRASH); category-completion verified in [odbc-crusher run 25025482604](https://github.com/fdcastel/odbc-crusher/actions/runs/25025482604)

