### PR TITLE
Fix garbled diagnostic record on failed SQLDriverConnect

### DIFF
--- a/IscDbc/JString.cpp
+++ b/IscDbc/JString.cpp
@@ -199,7 +199,7 @@ const char* JString::getString()
 return (string) ? string : "";
 }
 
-JString::operator const char* ()
+JString::operator const char* () const
 {
 /**************************************
  *

--- a/IscDbc/JString.h
+++ b/IscDbc/JString.h
@@ -61,7 +61,7 @@ public:
 
 	void		Format (const char*, ...);
 	const char	*getString();
-	operator const char*();
+	operator const char*() const;
 	JString& operator = (const char *string);
 	JString& operator = (const JString& string);
 	JString& operator+=(const char *string);

--- a/IscDbc/SQLError.cpp
+++ b/IscDbc/SQLError.cpp
@@ -112,7 +112,7 @@ SQLError::~SQLError () throw()
 
 }
 
-int SQLError::getSqlcode ()
+int SQLError::getSqlcode () const
 {
 /**************************************
  *
@@ -128,7 +128,7 @@ int SQLError::getSqlcode ()
 return sqlcode;
 }
 
-int SQLError::getFbcode ()
+int SQLError::getFbcode () const
 {
 /**************************************
  *
@@ -144,7 +144,7 @@ int SQLError::getFbcode ()
 return fbcode;
 }
 
-const char *SQLError::getText ()
+const char *SQLError::getText () const
 {
 /**************************************
  *
@@ -160,7 +160,7 @@ const char *SQLError::getText ()
 return text;
 }
 
-SQLError::operator const char* ()
+SQLError::operator const char* () const
 {
 /**************************************
  *
@@ -193,7 +193,7 @@ SQLError::SQLError( int code, __int64 codefb, const char * txt, ...)
 	fbcode = (int) codefb;
 }
 
-const char* SQLError::getTrace()
+const char* SQLError::getTrace() const
 {
 	return stackTrace;
 }

--- a/IscDbc/SQLError.h
+++ b/IscDbc/SQLError.h
@@ -33,18 +33,18 @@ class SQLError : public SQLException
 public:
 	virtual int release();
 	virtual void addRef();
-	virtual const char* getTrace();
+	virtual const char* getTrace() const;
 	SQLError (int sqlcode, __int64 fbcode, const char *text, ...);
 	SQLError (SqlCode sqlcode, const char *text, ...);
 	SQLError (Stream *trace, SqlCode code, const char *txt,...);
 	~SQLError() throw();
 
-	virtual int			getFbcode ();
-	virtual int			getSqlcode ();
-	virtual const char	*getText();
+	virtual int			getFbcode () const;
+	virtual int			getSqlcode () const;
+	virtual const char	*getText() const;
 
 	//void		Delete();
-	operator	const char*();
+	operator	const char*() const;
 
 	int		fbcode;
 	int		sqlcode;

--- a/IscDbc/SQLException.h
+++ b/IscDbc/SQLException.h
@@ -42,10 +42,10 @@ class DllExport SQLException : public std::exception
 public:
 	//virtual void		addRef() = 0;
 	//virtual int		release() = 0;
-	virtual int			getFbcode () = 0;
-	virtual int			getSqlcode () = 0;
-	virtual const char	*getText() = 0;
-	virtual const char	*getTrace() = 0;
+	virtual int			getFbcode () const = 0;
+	virtual int			getSqlcode () const = 0;
+	virtual const char	*getText() const = 0;
+	virtual const char	*getTrace() const = 0;
 };
 
 }; // end namespace IscDbcLibrary

--- a/OdbcConnection.cpp
+++ b/OdbcConnection.cpp
@@ -1026,10 +1026,14 @@ SQLRETURN OdbcConnection::sqlNativeSql( SQLCHAR * inStatementText, SQLINTEGER te
 			outText = (const char *)tempNative;
 
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError( "HY000", exception );
+		postError( "HY000", ex );
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError( "HY000", ex );
 		return SQL_ERROR;
 	}
 
@@ -1132,10 +1136,16 @@ SQLRETURN OdbcConnection::sqlDisconnect()
 		connection = NULL;
 		connected = false;
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("01002", exception);
+		postError ("01002", ex);
+		connection = NULL;
+		connected = false;
+		return SQL_SUCCESS_WITH_INFO;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("01002", ex);
 		connection = NULL;
 		connected = false;
 		return SQL_SUCCESS_WITH_INFO;
@@ -1632,6 +1642,21 @@ SQLRETURN OdbcConnection::connect(const char *sharedLibrary, const char * databa
 {
 	Properties *properties = NULL;
 
+	// Shared rollback for both catch handlers below. `connection` may be
+	// NULL if createConnection() itself threw before assignment, so it has
+	// to be checked before close().
+	auto rollbackPartialConnect = [&]() {
+		if ( env->envShare )
+			env->envShare = NULL;
+		if ( properties )
+			properties->release();
+		if ( connection )
+		{
+			connection->close();
+			connection = NULL;
+		}
+	};
+
 	try
 	{
 		connection = createConnection();
@@ -1709,19 +1734,15 @@ SQLRETURN OdbcConnection::connect(const char *sharedLibrary, const char * databa
 		WcsToMbs = connection->getConnectionWcsToMbs();
 		MbsToWcs = connection->getConnectionMbsToWcs();
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		if ( env->envShare )
-			env->envShare = NULL;
-
-		if ( properties )
-			properties->release();
-
-		connection->close();
-		connection = NULL;
-
-		return sqlReturn( SQL_ERROR, "08004", exception.getText(), exception.getSqlcode() );
+		rollbackPartialConnect();
+		return sqlReturn( SQL_ERROR, "08004", ex.getText(), ex.getSqlcode() );
+	}
+	catch (std::exception &ex)
+	{
+		rollbackPartialConnect();
+		return sqlReturn( SQL_ERROR, "08004", ex.what(), 0 );
 	}
 
 	connected = true;
@@ -1746,10 +1767,14 @@ SQLRETURN OdbcConnection::sqlEndTran(int operation)
 				connection->rollbackAuto();
 			}
 		}
-		catch ( std::exception &ex )
+		catch (SQLException &ex)
 		{
-			SQLException &exception = (SQLException&)ex;
-			postError ("S1000", exception);
+			postError ("S1000", ex);
+			return SQL_ERROR;
+		}
+		catch (std::exception &ex)
+		{
+			postError ("S1000", ex);
 			return SQL_ERROR;
 		}
 
@@ -1764,10 +1789,14 @@ SQLRETURN OdbcConnection::sqlExecuteCreateDatabase(const char * sqlString)
 	{
 		connection->sqlExecuteCreateDatabase( sqlString );
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError( "HY000", exception );
+		postError( "HY000", ex );
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError( "HY000", ex );
 		return SQL_ERROR;
 	}
 
@@ -2178,10 +2207,13 @@ void OdbcConnection::initUserEvents( PODBC_EVENTS_BLOCK_INFO infoEvents )
 		userEventsInterfase->events = infoEvents->events;
 		userEventsInterfase->count = infoEvents->count;
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError( "HY000", exception );
+		postError( "HY000", ex );
+	}
+	catch (std::exception &ex)
+	{
+		postError( "HY000", ex );
 	}
 }
 
@@ -2199,10 +2231,13 @@ void OdbcConnection::updateResultEvents( char *updated )
 			nextNameEvent->changed = userEvents->isChanged( i );
 		}
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError( "HY000", exception );
+		postError( "HY000", ex );
+	}
+	catch (std::exception &ex)
+	{
+		postError( "HY000", ex );
 	}
 }
 
@@ -2212,10 +2247,13 @@ void OdbcConnection::requeueEvents()
 	{
 		userEvents->queEvents( userEventsInterfase );
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError( "HY000", exception );
+		postError( "HY000", ex );
+	}
+	catch (std::exception &ex)
+	{
+		postError( "HY000", ex );
 	}
 }
 

--- a/OdbcConnection.cpp
+++ b/OdbcConnection.cpp
@@ -1026,12 +1026,12 @@ SQLRETURN OdbcConnection::sqlNativeSql( SQLCHAR * inStatementText, SQLINTEGER te
 			outText = (const char *)tempNative;
 
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError( "HY000", ex );
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError( "HY000", ex );
 		return SQL_ERROR;
@@ -1136,14 +1136,14 @@ SQLRETURN OdbcConnection::sqlDisconnect()
 		connection = NULL;
 		connected = false;
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("01002", ex);
 		connection = NULL;
 		connected = false;
 		return SQL_SUCCESS_WITH_INFO;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("01002", ex);
 		connection = NULL;
@@ -1734,12 +1734,12 @@ SQLRETURN OdbcConnection::connect(const char *sharedLibrary, const char * databa
 		WcsToMbs = connection->getConnectionWcsToMbs();
 		MbsToWcs = connection->getConnectionMbsToWcs();
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		rollbackPartialConnect();
 		return sqlReturn( SQL_ERROR, "08004", ex.getText(), ex.getSqlcode() );
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		rollbackPartialConnect();
 		return sqlReturn( SQL_ERROR, "08004", ex.what(), 0 );
@@ -1767,12 +1767,12 @@ SQLRETURN OdbcConnection::sqlEndTran(int operation)
 				connection->rollbackAuto();
 			}
 		}
-		catch (SQLException &ex)
+		catch (const SQLException &ex)
 		{
 			postError ("S1000", ex);
 			return SQL_ERROR;
 		}
-		catch (std::exception &ex)
+		catch (const std::exception &ex)
 		{
 			postError ("S1000", ex);
 			return SQL_ERROR;
@@ -1789,12 +1789,12 @@ SQLRETURN OdbcConnection::sqlExecuteCreateDatabase(const char * sqlString)
 	{
 		connection->sqlExecuteCreateDatabase( sqlString );
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError( "HY000", ex );
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError( "HY000", ex );
 		return SQL_ERROR;
@@ -2207,11 +2207,11 @@ void OdbcConnection::initUserEvents( PODBC_EVENTS_BLOCK_INFO infoEvents )
 		userEventsInterfase->events = infoEvents->events;
 		userEventsInterfase->count = infoEvents->count;
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError( "HY000", ex );
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError( "HY000", ex );
 	}
@@ -2231,11 +2231,11 @@ void OdbcConnection::updateResultEvents( char *updated )
 			nextNameEvent->changed = userEvents->isChanged( i );
 		}
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError( "HY000", ex );
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError( "HY000", ex );
 	}
@@ -2247,11 +2247,11 @@ void OdbcConnection::requeueEvents()
 	{
 		userEvents->queEvents( userEventsInterfase );
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError( "HY000", ex );
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError( "HY000", ex );
 	}

--- a/OdbcConnection.cpp
+++ b/OdbcConnection.cpp
@@ -1028,12 +1028,12 @@ SQLRETURN OdbcConnection::sqlNativeSql( SQLCHAR * inStatementText, SQLINTEGER te
 	}
 	catch (const SQLException &ex)
 	{
-		postError( "HY000", ex );
+		postError("HY000", ex);
 		return SQL_ERROR;
 	}
 	catch (const std::exception &ex)
 	{
-		postError( "HY000", ex );
+		postError("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -1129,6 +1129,14 @@ SQLRETURN OdbcConnection::sqlDisconnect()
 	if (connection->getTransactionPending())
 		return sqlReturn (SQL_ERROR, "25000", "Invalid transaction state");
 
+	auto handle_error = [&](const char* state, auto& ex) ->  SQLRETURN
+	{
+		postError("01002", ex);
+		connection = NULL;
+		connected = false;
+		return SQL_SUCCESS_WITH_INFO;
+	};
+
 	try
 	{
 		connection->commit();
@@ -1138,17 +1146,11 @@ SQLRETURN OdbcConnection::sqlDisconnect()
 	}
 	catch (const SQLException &ex)
 	{
-		postError ("01002", ex);
-		connection = NULL;
-		connected = false;
-		return SQL_SUCCESS_WITH_INFO;
+		return handle_error("01002", ex);
 	}
 	catch (const std::exception &ex)
 	{
-		postError ("01002", ex);
-		connection = NULL;
-		connected = false;
-		return SQL_SUCCESS_WITH_INFO;
+		return handle_error("01002", ex);
 	}
 
 	return sqlSuccess();

--- a/OdbcDesc.cpp
+++ b/OdbcDesc.cpp
@@ -805,12 +805,12 @@ SQLRETURN OdbcDesc::sqlGetDescField(int recNumber, int fieldId, SQLPOINTER ptr, 
 			return returnStringInfo (ptr, bufferLength, lengthPtr, (char*)string);
 
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -1220,12 +1220,12 @@ SQLRETURN OdbcDesc::sqlGetDescRec(	SQLSMALLINT recNumber,
 		*scalePtr = record->scale;
 		*nullablePtr = record->nullable;
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -1272,12 +1272,12 @@ SQLRETURN OdbcDesc::sqlSetDescRec(	SQLSMALLINT	recNumber,
 		record->octetLengthPtr = stringLengthPtr;
 		record->indicatorPtr = indicatorPtr;
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;

--- a/OdbcDesc.cpp
+++ b/OdbcDesc.cpp
@@ -1253,13 +1253,10 @@ SQLRETURN OdbcDesc::sqlSetDescRec(	SQLSMALLINT	recNumber,
 	if ( bDefined == false )
 		return sqlReturn (SQL_ERROR, "HY091", "Invalid descriptor field identifier");
 
-	if (recNumber)
-	{
-		if ( recNumber > headCount )
-			return sqlReturn (SQL_NO_DATA_FOUND, "HY021", "Inconsistent descriptor information");
+	if ( recNumber > headCount )
+		return sqlReturn (SQL_NO_DATA_FOUND, "HY021", "Inconsistent descriptor information");
 
-		record = getDescRecord (recNumber);
-	}
+	record = getDescRecord (recNumber);
 
 	try
 	{

--- a/OdbcDesc.cpp
+++ b/OdbcDesc.cpp
@@ -805,10 +805,14 @@ SQLRETURN OdbcDesc::sqlGetDescField(int recNumber, int fieldId, SQLPOINTER ptr, 
 			return returnStringInfo (ptr, bufferLength, lengthPtr, (char*)string);
 
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -1216,10 +1220,14 @@ SQLRETURN OdbcDesc::sqlGetDescRec(	SQLSMALLINT recNumber,
 		*scalePtr = record->scale;
 		*nullablePtr = record->nullable;
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -1264,10 +1272,14 @@ SQLRETURN OdbcDesc::sqlSetDescRec(	SQLSMALLINT	recNumber,
 		record->octetLengthPtr = stringLengthPtr;
 		record->indicatorPtr = indicatorPtr;
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 

--- a/OdbcEnv.cpp
+++ b/OdbcEnv.cpp
@@ -132,12 +132,12 @@ SQLRETURN OdbcEnv::sqlEndTran(int operation)
 		{
 			envShare->sqlEndTran (operation);
 		}
-		catch (SQLException &ex)
+		catch (const SQLException &ex)
 		{
 			postError ("HY000", ex);
 			return SQL_ERROR;
 		}
-		catch (std::exception &ex)
+		catch (const std::exception &ex)
 		{
 			postError ("HY000", ex);
 			return SQL_ERROR;
@@ -196,12 +196,12 @@ SQLRETURN OdbcEnv::sqlGetEnvAttr(int attribute, SQLPOINTER ptr, int bufferLength
 		if (lengthPtr)
 			*lengthPtr = sizeof (int);
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -230,12 +230,12 @@ SQLRETURN OdbcEnv::sqlSetEnvAttr(int attribute, SQLPOINTER value, int length)
 			return sqlReturn (SQL_ERROR, "HYC00", "Optional feature not implemented");
 		}
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;

--- a/OdbcEnv.cpp
+++ b/OdbcEnv.cpp
@@ -132,10 +132,14 @@ SQLRETURN OdbcEnv::sqlEndTran(int operation)
 		{
 			envShare->sqlEndTran (operation);
 		}
-		catch ( std::exception &ex )
+		catch (SQLException &ex)
 		{
-			SQLException &exception = (SQLException&)ex;
-			postError ("HY000", exception);
+			postError ("HY000", ex);
+			return SQL_ERROR;
+		}
+		catch (std::exception &ex)
+		{
+			postError ("HY000", ex);
 			return SQL_ERROR;
 		}
 
@@ -192,10 +196,14 @@ SQLRETURN OdbcEnv::sqlGetEnvAttr(int attribute, SQLPOINTER ptr, int bufferLength
 		if (lengthPtr)
 			*lengthPtr = sizeof (int);
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -222,10 +230,14 @@ SQLRETURN OdbcEnv::sqlSetEnvAttr(int attribute, SQLPOINTER value, int length)
 			return sqlReturn (SQL_ERROR, "HYC00", "Optional feature not implemented");
 		}
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 			

--- a/OdbcJdbcSetup/DsnDialog.cpp
+++ b/OdbcJdbcSetup/DsnDialog.cpp
@@ -789,11 +789,20 @@ void CDsnDialog::OnTestConnection( HWND hDlg )
 
 		MessageBox( hDlg, _TR( IDS_MESSAGE_01, "Connection successful!" ), TEXT( strHeadDlg ), MB_ICONINFORMATION | MB_OK );
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
 		char buffer[2048];
-		JString text = exception.getText();
+		JString text = ex.getText();
+
+		sprintf( buffer, "%s\n%s", _TR( IDS_MESSAGE_02, "Connection failed!" ), (const char*)text );
+		removeNameFileDBfromMessage ( buffer );
+
+		MessageBox( hDlg, TEXT( buffer ), TEXT( strHeadDlg ), MB_ICONERROR | MB_OK );
+	}
+	catch (std::exception &ex)
+	{
+		char buffer[2048];
+		JString text = ex.what();
 
 		sprintf( buffer, "%s\n%s", _TR( IDS_MESSAGE_02, "Connection failed!" ), (const char*)text );
 		removeNameFileDBfromMessage ( buffer );

--- a/OdbcJdbcSetup/DsnDialog.cpp
+++ b/OdbcJdbcSetup/DsnDialog.cpp
@@ -789,7 +789,7 @@ void CDsnDialog::OnTestConnection( HWND hDlg )
 
 		MessageBox( hDlg, _TR( IDS_MESSAGE_01, "Connection successful!" ), TEXT( strHeadDlg ), MB_ICONINFORMATION | MB_OK );
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		char buffer[2048];
 		JString text = ex.getText();
@@ -799,7 +799,7 @@ void CDsnDialog::OnTestConnection( HWND hDlg )
 
 		MessageBox( hDlg, TEXT( buffer ), TEXT( strHeadDlg ), MB_ICONERROR | MB_OK );
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		char buffer[2048];
 		JString text = ex.what();

--- a/OdbcJdbcSetup/DsnDialog.cpp
+++ b/OdbcJdbcSetup/DsnDialog.cpp
@@ -743,6 +743,14 @@ void CDsnDialog::OnTestConnection( HWND hDlg )
 
 	GetWindowText( hDlg, strHeadDlg, sizeof ( strHeadDlg ) );
 
+	auto handle_error = [&](const char* text)
+	{
+		char buffer[2048];
+		sprintf(buffer, "%s\n%s", _TR(IDS_MESSAGE_02, "Connection failed!"), text);
+		removeNameFileDBfromMessage(buffer);
+		MessageBox(hDlg, TEXT(buffer), TEXT(strHeadDlg), MB_ICONERROR | MB_OK);
+	};
+
 	try
 	{
 		CServiceClient services;
@@ -791,23 +799,11 @@ void CDsnDialog::OnTestConnection( HWND hDlg )
 	}
 	catch (const SQLException &ex)
 	{
-		char buffer[2048];
-		JString text = ex.getText();
-
-		sprintf( buffer, "%s\n%s", _TR( IDS_MESSAGE_02, "Connection failed!" ), (const char*)text );
-		removeNameFileDBfromMessage ( buffer );
-
-		MessageBox( hDlg, TEXT( buffer ), TEXT( strHeadDlg ), MB_ICONERROR | MB_OK );
+		handle_error(ex.getText());
 	}
 	catch (const std::exception &ex)
 	{
-		char buffer[2048];
-		JString text = ex.what();
-
-		sprintf( buffer, "%s\n%s", _TR( IDS_MESSAGE_02, "Connection failed!" ), (const char*)text );
-		removeNameFileDBfromMessage ( buffer );
-
-		MessageBox( hDlg, TEXT( buffer ), TEXT( strHeadDlg ), MB_ICONERROR | MB_OK );
+		handle_error(ex.what());
 	}
 }
 #endif

--- a/OdbcJdbcSetup/ServiceClient.cpp
+++ b/OdbcJdbcSetup/ServiceClient.cpp
@@ -84,21 +84,8 @@ bool CServiceClient::initServices( const char *sharedLibrary )
 		if ( !properties )
 			return false;
 	}
-	catch (const SQLException &ex)
+	catch (const std::exception &ex) // SQLException is derived from the std::exception and should be also caught here
 	{
-		JString text = ex.getText();
-
-		if ( services )
-		{
-			services->release();
-			services = NULL;
-			return false;
-		}
-	}
-	catch (const std::exception &ex)
-	{
-		JString text = ex.what();
-
 		if ( services )
 		{
 			services->release();
@@ -153,19 +140,8 @@ bool CServiceClient::createDatabase()
 								    properties );
 		connection->close();
 	}
-	catch (const SQLException &ex)
+	catch (const std::exception &ex) // SQLException is derived from the std::exception and should be also caught here
 	{
-		JString text = ex.getText();
-
-		if ( connection )
-			connection->close();
-
-		return false;
-	}
-	catch (const std::exception &ex)
-	{
-		JString text = ex.what();
-
 		if ( connection )
 			connection->close();
 
@@ -205,19 +181,8 @@ bool CServiceClient::dropDatabase()
 								  properties );
 		connection->close();
 	}
-	catch (const SQLException &ex)
+	catch (const std::exception &ex) // SQLException is derived from the std::exception and should be also caught here
 	{
-		JString text = ex.getText();
-
-		if ( connection )
-			connection->close();
-
-		return false;
-	}
-	catch (const std::exception &ex)
-	{
-		JString text = ex.what();
-
 		if ( connection )
 			connection->close();
 

--- a/OdbcJdbcSetup/ServiceClient.cpp
+++ b/OdbcJdbcSetup/ServiceClient.cpp
@@ -84,10 +84,20 @@ bool CServiceClient::initServices( const char *sharedLibrary )
 		if ( !properties )
 			return false;
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		JString text = exception.getText();
+		JString text = ex.getText();
+
+		if ( services )
+		{
+			services->release();
+			services = NULL;
+			return false;
+		}
+	}
+	catch (std::exception &ex)
+	{
+		JString text = ex.what();
 
 		if ( services )
 		{
@@ -143,10 +153,18 @@ bool CServiceClient::createDatabase()
 								    properties );
 		connection->close();
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		JString text = exception.getText();
+		JString text = ex.getText();
+
+		if ( connection )
+			connection->close();
+
+		return false;
+	}
+	catch (std::exception &ex)
+	{
+		JString text = ex.what();
 
 		if ( connection )
 			connection->close();
@@ -187,10 +205,18 @@ bool CServiceClient::dropDatabase()
 								  properties );
 		connection->close();
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		JString text = exception.getText();
+		JString text = ex.getText();
+
+		if ( connection )
+			connection->close();
+
+		return false;
+	}
+	catch (std::exception &ex)
+	{
+		JString text = ex.what();
 
 		if ( connection )
 			connection->close();

--- a/OdbcJdbcSetup/ServiceClient.cpp
+++ b/OdbcJdbcSetup/ServiceClient.cpp
@@ -84,7 +84,7 @@ bool CServiceClient::initServices( const char *sharedLibrary )
 		if ( !properties )
 			return false;
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		JString text = ex.getText();
 
@@ -95,7 +95,7 @@ bool CServiceClient::initServices( const char *sharedLibrary )
 			return false;
 		}
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		JString text = ex.what();
 
@@ -153,7 +153,7 @@ bool CServiceClient::createDatabase()
 								    properties );
 		connection->close();
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		JString text = ex.getText();
 
@@ -162,7 +162,7 @@ bool CServiceClient::createDatabase()
 
 		return false;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		JString text = ex.what();
 
@@ -205,7 +205,7 @@ bool CServiceClient::dropDatabase()
 								  properties );
 		connection->close();
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		JString text = ex.getText();
 
@@ -214,7 +214,7 @@ bool CServiceClient::dropDatabase()
 
 		return false;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		JString text = ex.what();
 

--- a/OdbcJdbcSetup/ServiceTabBackup.cpp
+++ b/OdbcJdbcSetup/ServiceTabBackup.cpp
@@ -234,16 +234,26 @@ void CServiceTabBackup::onStartBackup()
 		SendMessage( hWndBar, PBM_SETPOS, (WPARAM)100 , (LPARAM)NULL );
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
 		writeFooterToLogFile();
 		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
 
 		char buffer[1024];
-		SQLException &exception = (SQLException&)ex;
-		JString text = exception.getText();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", exception.getSqlcode(), exception.getFbcode(), (const char*)text );
+		JString text = ex.getText();
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
+		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+	}
+	catch (std::exception &ex)
+	{
+		writeFooterToLogFile();
+		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
+		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
+
+		char buffer[1024];
+		JString text = ex.what();
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
 		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
 	}
 

--- a/OdbcJdbcSetup/ServiceTabBackup.cpp
+++ b/OdbcJdbcSetup/ServiceTabBackup.cpp
@@ -234,7 +234,7 @@ void CServiceTabBackup::onStartBackup()
 		SendMessage( hWndBar, PBM_SETPOS, (WPARAM)100 , (LPARAM)NULL );
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		writeFooterToLogFile();
 		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
@@ -245,7 +245,7 @@ void CServiceTabBackup::onStartBackup()
 		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
 		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		writeFooterToLogFile();
 		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );

--- a/OdbcJdbcSetup/ServiceTabBackup.cpp
+++ b/OdbcJdbcSetup/ServiceTabBackup.cpp
@@ -179,6 +179,17 @@ void CServiceTabBackup::onStartBackup()
 		return;
 	}
 
+	auto handle_error = [&](const char* text, int sqlcode = 0, int fbcode = 0)
+	{
+		writeFooterToLogFile();
+		EnableWindow(GetDlgItem(hDlg, IDOK), TRUE);
+		EnableWindow(GetDlgItem(hDlg, IDC_BUTTON_VIEW_LOG), !logPathFile.IsEmpty());
+
+		char buffer[1024];
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", sqlcode, fbcode, text);
+		MessageBox(NULL, buffer, TEXT("Error!"), MB_ICONERROR | MB_OK);
+	};
+
 	try
 	{
 		DWORD dwWritten;
@@ -236,25 +247,11 @@ void CServiceTabBackup::onStartBackup()
 	}
 	catch (const SQLException &ex)
 	{
-		writeFooterToLogFile();
-		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
-		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
-
-		char buffer[1024];
-		JString text = ex.getText();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
-		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+		handle_error(ex.getText(), ex.getSqlcode(), ex.getFbcode());
 	}
 	catch (const std::exception &ex)
 	{
-		writeFooterToLogFile();
-		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
-		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
-
-		char buffer[1024];
-		JString text = ex.what();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
-		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+		handle_error(ex.what());
 	}
 
 	services.closeService();

--- a/OdbcJdbcSetup/ServiceTabRepair.cpp
+++ b/OdbcJdbcSetup/ServiceTabRepair.cpp
@@ -301,16 +301,26 @@ void CServiceTabRepair::startRepairDatabase()
 		SendMessage( hWndBar, PBM_SETPOS, (WPARAM)100 , (LPARAM)NULL );
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
 		writeFooterToLogFile();
 		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
 
 		char buffer[1024];
-		SQLException &exception = (SQLException&)ex;
-		JString text = exception.getText();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", exception.getSqlcode(), exception.getFbcode(), (const char*)text );
+		JString text = ex.getText();
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
+		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+	}
+	catch (std::exception &ex)
+	{
+		writeFooterToLogFile();
+		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
+		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
+
+		char buffer[1024];
+		JString text = ex.what();
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
 		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
 	}
 

--- a/OdbcJdbcSetup/ServiceTabRepair.cpp
+++ b/OdbcJdbcSetup/ServiceTabRepair.cpp
@@ -301,7 +301,7 @@ void CServiceTabRepair::startRepairDatabase()
 		SendMessage( hWndBar, PBM_SETPOS, (WPARAM)100 , (LPARAM)NULL );
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		writeFooterToLogFile();
 		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
@@ -312,7 +312,7 @@ void CServiceTabRepair::startRepairDatabase()
 		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
 		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		writeFooterToLogFile();
 		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );

--- a/OdbcJdbcSetup/ServiceTabRepair.cpp
+++ b/OdbcJdbcSetup/ServiceTabRepair.cpp
@@ -200,6 +200,17 @@ void CServiceTabRepair::startRepairDatabase()
 		return;
 	}
 
+	auto handle_error = [&](const char* text, int sqlcode = 0, int fbcode = 0)
+	{
+		writeFooterToLogFile();
+		EnableWindow(GetDlgItem(hDlg, IDOK), TRUE);
+		EnableWindow(GetDlgItem(hDlg, IDC_BUTTON_VIEW_LOG), !logPathFile.IsEmpty());
+
+		char buffer[1024];
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", sqlcode, fbcode, text);
+		MessageBox(NULL, buffer, TEXT("Error!"), MB_ICONERROR | MB_OK);
+	};
+
 	try
 	{
 		DWORD dwWritten;
@@ -303,25 +314,11 @@ void CServiceTabRepair::startRepairDatabase()
 	}
 	catch (const SQLException &ex)
 	{
-		writeFooterToLogFile();
-		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
-		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
-
-		char buffer[1024];
-		JString text = ex.getText();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
-		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+		handle_error(ex.getText(), ex.getSqlcode(), ex.getFbcode());
 	}
 	catch (const std::exception &ex)
 	{
-		writeFooterToLogFile();
-		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
-		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
-
-		char buffer[1024];
-		JString text = ex.what();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
-		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+		handle_error(ex.what());
 	}
 
 	services.closeService();

--- a/OdbcJdbcSetup/ServiceTabRestore.cpp
+++ b/OdbcJdbcSetup/ServiceTabRestore.cpp
@@ -263,16 +263,26 @@ void CServiceTabRestore::onStartRestore()
 		SendMessage( hWndBar, PBM_SETPOS, (WPARAM)100 , (LPARAM)NULL );
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
 		writeFooterToLogFile();
 		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
 
 		char buffer[1024];
-		SQLException &exception = (SQLException&)ex;
-		JString text = exception.getText();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", exception.getSqlcode(), exception.getFbcode(), (const char*)text );
+		JString text = ex.getText();
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
+		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+	}
+	catch (std::exception &ex)
+	{
+		writeFooterToLogFile();
+		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
+		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
+
+		char buffer[1024];
+		JString text = ex.what();
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
 		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
 	}
 

--- a/OdbcJdbcSetup/ServiceTabRestore.cpp
+++ b/OdbcJdbcSetup/ServiceTabRestore.cpp
@@ -205,6 +205,17 @@ void CServiceTabRestore::onStartRestore()
 		return;
 	}
 
+	auto handle_error = [&](const char* text, int sqlcode = 0, int fbcode = 0)
+	{
+		writeFooterToLogFile();
+		EnableWindow(GetDlgItem(hDlg, IDOK), TRUE);
+		EnableWindow(GetDlgItem(hDlg, IDC_BUTTON_VIEW_LOG), !logPathFile.IsEmpty());
+
+		char buffer[1024];
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", sqlcode, fbcode, text);
+		MessageBox(NULL, buffer, TEXT("Error!"), MB_ICONERROR | MB_OK);
+	};
+
 	try
 	{
 		DWORD dwWritten;
@@ -265,25 +276,11 @@ void CServiceTabRestore::onStartRestore()
 	}
 	catch (const SQLException &ex)
 	{
-		writeFooterToLogFile();
-		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
-		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
-
-		char buffer[1024];
-		JString text = ex.getText();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
-		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+		handle_error(ex.getText(), ex.getSqlcode(), ex.getFbcode());
 	}
 	catch (const std::exception &ex)
 	{
-		writeFooterToLogFile();
-		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
-		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
-
-		char buffer[1024];
-		JString text = ex.what();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
-		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+		handle_error(ex.what());
 	}
 
 	services.closeService();

--- a/OdbcJdbcSetup/ServiceTabRestore.cpp
+++ b/OdbcJdbcSetup/ServiceTabRestore.cpp
@@ -263,7 +263,7 @@ void CServiceTabRestore::onStartRestore()
 		SendMessage( hWndBar, PBM_SETPOS, (WPARAM)100 , (LPARAM)NULL );
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		writeFooterToLogFile();
 		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
@@ -274,7 +274,7 @@ void CServiceTabRestore::onStartRestore()
 		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
 		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		writeFooterToLogFile();
 		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );

--- a/OdbcJdbcSetup/ServiceTabStatistics.cpp
+++ b/OdbcJdbcSetup/ServiceTabStatistics.cpp
@@ -177,6 +177,17 @@ void CServiceTabStatistics::onStartStatistics()
 		return;
 	}
 
+	auto handle_error = [&](const char* text, int sqlcode = 0, int fbcode = 0)
+	{
+		writeFooterToLogFile();
+		EnableWindow(GetDlgItem(hDlg, IDOK), TRUE);
+		EnableWindow(GetDlgItem(hDlg, IDC_BUTTON_VIEW_LOG), !logPathFile.IsEmpty());
+
+		char buffer[1024];
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", sqlcode, fbcode, text);
+		MessageBox(NULL, buffer, TEXT("Error!"), MB_ICONERROR | MB_OK);
+	};
+
 	try
 	{
 		DWORD dwWritten;
@@ -221,25 +232,11 @@ void CServiceTabStatistics::onStartStatistics()
 	}
 	catch (const SQLException &ex)
 	{
-		writeFooterToLogFile();
-		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
-		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
-
-		char buffer[1024];
-		JString text = ex.getText();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
-		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+		handle_error(ex.getText(), ex.getSqlcode(), ex.getFbcode());
 	}
 	catch (const std::exception &ex)
 	{
-		writeFooterToLogFile();
-		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
-		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
-
-		char buffer[1024];
-		JString text = ex.what();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
-		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+		handle_error(ex.what());
 	}
 
 	services.closeService();

--- a/OdbcJdbcSetup/ServiceTabStatistics.cpp
+++ b/OdbcJdbcSetup/ServiceTabStatistics.cpp
@@ -219,7 +219,7 @@ void CServiceTabStatistics::onStartStatistics()
 		SendMessage( hWndBar, PBM_SETPOS, (WPARAM)100 , (LPARAM)NULL );
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		writeFooterToLogFile();
 		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
@@ -230,7 +230,7 @@ void CServiceTabStatistics::onStartStatistics()
 		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
 		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		writeFooterToLogFile();
 		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );

--- a/OdbcJdbcSetup/ServiceTabStatistics.cpp
+++ b/OdbcJdbcSetup/ServiceTabStatistics.cpp
@@ -219,16 +219,26 @@ void CServiceTabStatistics::onStartStatistics()
 		SendMessage( hWndBar, PBM_SETPOS, (WPARAM)100 , (LPARAM)NULL );
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
 		writeFooterToLogFile();
 		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
 
 		char buffer[1024];
-		SQLException &exception = (SQLException&)ex;
-		JString text = exception.getText();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", exception.getSqlcode(), exception.getFbcode(), (const char*)text );
+		JString text = ex.getText();
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
+		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+	}
+	catch (std::exception &ex)
+	{
+		writeFooterToLogFile();
+		EnableWindow( GetDlgItem( hDlg, IDOK ), TRUE );
+		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_VIEW_LOG ), !logPathFile.IsEmpty() );
+
+		char buffer[1024];
+		JString text = ex.what();
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
 		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
 	}
 

--- a/OdbcJdbcSetup/Setup.cpp
+++ b/OdbcJdbcSetup/Setup.cpp
@@ -1068,12 +1068,18 @@ bool Setup::addDsn()
 
 					return true;
 				}
-				catch ( std::exception &ex )
+				catch (SQLException &ex)
 				{
 					char buffer[1024];
-					SQLException &exception = (SQLException&)ex;
-					JString text = exception.getText();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", exception.getSqlcode(), exception.getFbcode(), (const char*)text );
+					JString text = ex.getText();
+					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
+					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+				}
+				catch (std::exception &ex)
+				{
+					char buffer[1024];
+					JString text = ex.what();
+					sprintf( buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
 					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
 				}
 			}
@@ -1128,12 +1134,18 @@ bool Setup::addDsn()
 
 					return true;
 				}
-				catch ( std::exception &ex )
+				catch (SQLException &ex)
 				{
 					char buffer[1024];
-					SQLException &exception = (SQLException&)ex;
-					JString text = exception.getText();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", exception.getSqlcode(), exception.getFbcode(), (const char*)text );
+					JString text = ex.getText();
+					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
+					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+				}
+				catch (std::exception &ex)
+				{
+					char buffer[1024];
+					JString text = ex.what();
+					sprintf( buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
 					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
 				}
 			}
@@ -1168,12 +1180,18 @@ bool Setup::addDsn()
 
 					return true;
 				}
-				catch ( std::exception &ex )
+				catch (SQLException &ex)
 				{
 					char buffer[1024];
-					SQLException &exception = (SQLException&)ex;
-					JString text = exception.getText();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", exception.getSqlcode(), exception.getFbcode(), (const char*)text );
+					JString text = ex.getText();
+					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
+					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+				}
+				catch (std::exception &ex)
+				{
+					char buffer[1024];
+					JString text = ex.what();
+					sprintf( buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
 					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
 				}
 			}
@@ -1338,12 +1356,18 @@ bool Setup::removeDsn()
 
 					return true;
 				}
-				catch ( std::exception &ex )
+				catch (SQLException &ex)
 				{
 					char buffer[1024];
-					SQLException &exception = (SQLException&)ex;
-					JString text = exception.getText();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", exception.getSqlcode(), exception.getFbcode(), (const char*)text );
+					JString text = ex.getText();
+					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
+					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+				}
+				catch (std::exception &ex)
+				{
+					char buffer[1024];
+					JString text = ex.what();
+					sprintf( buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
 					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
 				}
 			}
@@ -1398,12 +1422,18 @@ bool Setup::removeDsn()
 
 					return true;
 				}
-				catch ( std::exception &ex )
+				catch (SQLException &ex)
 				{
 					char buffer[1024];
-					SQLException &exception = (SQLException&)ex;
-					JString text = exception.getText();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", exception.getSqlcode(), exception.getFbcode(), (const char*)text );
+					JString text = ex.getText();
+					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
+					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+				}
+				catch (std::exception &ex)
+				{
+					char buffer[1024];
+					JString text = ex.what();
+					sprintf( buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
 					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
 				}
 			}
@@ -1438,12 +1468,18 @@ bool Setup::removeDsn()
 
 					return true;
 				}
-				catch ( std::exception &ex )
+				catch (SQLException &ex)
 				{
 					char buffer[1024];
-					SQLException &exception = (SQLException&)ex;
-					JString text = exception.getText();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", exception.getSqlcode(), exception.getFbcode(), (const char*)text );
+					JString text = ex.getText();
+					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
+					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+				}
+				catch (std::exception &ex)
+				{
+					char buffer[1024];
+					JString text = ex.what();
+					sprintf( buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
 					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
 				}
 			}

--- a/OdbcJdbcSetup/Setup.cpp
+++ b/OdbcJdbcSetup/Setup.cpp
@@ -950,6 +950,13 @@ bool Setup::addDsn()
 		char buffer[1024];
 		CServiceClient services;
 
+		auto handle_error = [&](const char* text, int sqlcode = 0, int fbcode = 0)
+		{
+			char buffer[1024];
+			sprintf(buffer, "sqlcode %d, fbcode %d - %s", sqlcode, fbcode, text);
+			SQLPostInstallerError(ODBC_ERROR_CREATE_DSN_FAILED, buffer);
+		};
+
 		if ( !services.initServices( jdbcDriver ) )
 		{
 			JString text;
@@ -1070,17 +1077,11 @@ bool Setup::addDsn()
 				}
 				catch (const SQLException &ex)
 				{
-					char buffer[1024];
-					JString text = ex.getText();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
-					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+					handle_error(ex.getText(), ex.getSqlcode(), ex.getFbcode());
 				}
 				catch (const std::exception &ex)
 				{
-					char buffer[1024];
-					JString text = ex.what();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
-					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+					handle_error(ex.what());
 				}
 			}
 			return false;
@@ -1136,17 +1137,11 @@ bool Setup::addDsn()
 				}
 				catch (const SQLException &ex)
 				{
-					char buffer[1024];
-					JString text = ex.getText();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
-					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+					handle_error(ex.getText(), ex.getSqlcode(), ex.getFbcode());
 				}
 				catch (const std::exception &ex)
 				{
-					char buffer[1024];
-					JString text = ex.what();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
-					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+					handle_error(ex.what());
 				}
 			}
 			return false;
@@ -1182,17 +1177,11 @@ bool Setup::addDsn()
 				}
 				catch (const SQLException &ex)
 				{
-					char buffer[1024];
-					JString text = ex.getText();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
-					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+					handle_error(ex.getText(), ex.getSqlcode(), ex.getFbcode());
 				}
 				catch (const std::exception &ex)
 				{
-					char buffer[1024];
-					JString text = ex.what();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
-					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+					handle_error(ex.what());
 				}
 			}
 			return false;
@@ -1216,6 +1205,13 @@ bool Setup::addDsn()
 
 bool Setup::removeDsn()
 {
+	auto handle_error = [&](const char* text, int sqlcode = 0, int fbcode = 0)
+	{
+		char buffer[1024];
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", sqlcode, fbcode, text);
+		SQLPostInstallerError(ODBC_ERROR_REMOVE_DSN_FAILED, buffer);
+	};
+
 	if ( !dsn.IsEmpty() )
 		SQLRemoveDSNFromIni (dsn);
 
@@ -1358,17 +1354,11 @@ bool Setup::removeDsn()
 				}
 				catch (const SQLException &ex)
 				{
-					char buffer[1024];
-					JString text = ex.getText();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
-					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+					handle_error(ex.getText(), ex.getSqlcode(), ex.getFbcode());
 				}
 				catch (const std::exception &ex)
 				{
-					char buffer[1024];
-					JString text = ex.what();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
-					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+					handle_error(ex.what());
 				}
 			}
 			return false;
@@ -1424,17 +1414,11 @@ bool Setup::removeDsn()
 				}
 				catch (const SQLException &ex)
 				{
-					char buffer[1024];
-					JString text = ex.getText();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
-					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+					handle_error(ex.getText(), ex.getSqlcode(), ex.getFbcode());
 				}
 				catch (const std::exception &ex)
 				{
-					char buffer[1024];
-					JString text = ex.what();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
-					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+					handle_error(ex.what());
 				}
 			}
 			return false;
@@ -1470,17 +1454,11 @@ bool Setup::removeDsn()
 				}
 				catch (const SQLException &ex)
 				{
-					char buffer[1024];
-					JString text = ex.getText();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
-					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+					handle_error(ex.getText(), ex.getSqlcode(), ex.getFbcode());
 				}
 				catch (const std::exception &ex)
 				{
-					char buffer[1024];
-					JString text = ex.what();
-					sprintf( buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
-					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
+					handle_error(ex.what());
 				}
 			}
 			return false;

--- a/OdbcJdbcSetup/Setup.cpp
+++ b/OdbcJdbcSetup/Setup.cpp
@@ -1068,14 +1068,14 @@ bool Setup::addDsn()
 
 					return true;
 				}
-				catch (SQLException &ex)
+				catch (const SQLException &ex)
 				{
 					char buffer[1024];
 					JString text = ex.getText();
 					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
 					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
 				}
-				catch (std::exception &ex)
+				catch (const std::exception &ex)
 				{
 					char buffer[1024];
 					JString text = ex.what();
@@ -1134,14 +1134,14 @@ bool Setup::addDsn()
 
 					return true;
 				}
-				catch (SQLException &ex)
+				catch (const SQLException &ex)
 				{
 					char buffer[1024];
 					JString text = ex.getText();
 					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
 					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
 				}
-				catch (std::exception &ex)
+				catch (const std::exception &ex)
 				{
 					char buffer[1024];
 					JString text = ex.what();
@@ -1180,14 +1180,14 @@ bool Setup::addDsn()
 
 					return true;
 				}
-				catch (SQLException &ex)
+				catch (const SQLException &ex)
 				{
 					char buffer[1024];
 					JString text = ex.getText();
 					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
 					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
 				}
-				catch (std::exception &ex)
+				catch (const std::exception &ex)
 				{
 					char buffer[1024];
 					JString text = ex.what();
@@ -1356,14 +1356,14 @@ bool Setup::removeDsn()
 
 					return true;
 				}
-				catch (SQLException &ex)
+				catch (const SQLException &ex)
 				{
 					char buffer[1024];
 					JString text = ex.getText();
 					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
 					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
 				}
-				catch (std::exception &ex)
+				catch (const std::exception &ex)
 				{
 					char buffer[1024];
 					JString text = ex.what();
@@ -1422,14 +1422,14 @@ bool Setup::removeDsn()
 
 					return true;
 				}
-				catch (SQLException &ex)
+				catch (const SQLException &ex)
 				{
 					char buffer[1024];
 					JString text = ex.getText();
 					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
 					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
 				}
-				catch (std::exception &ex)
+				catch (const std::exception &ex)
 				{
 					char buffer[1024];
 					JString text = ex.what();
@@ -1468,14 +1468,14 @@ bool Setup::removeDsn()
 
 					return true;
 				}
-				catch (SQLException &ex)
+				catch (const SQLException &ex)
 				{
 					char buffer[1024];
 					JString text = ex.getText();
 					sprintf( buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
 					SQLPostInstallerError( ODBC_ERROR_CREATE_DSN_FAILED, buffer );
 				}
-				catch (std::exception &ex)
+				catch (const std::exception &ex)
 				{
 					char buffer[1024];
 					JString text = ex.what();

--- a/OdbcJdbcSetup/UsersTabUsers.cpp
+++ b/OdbcJdbcSetup/UsersTabUsers.cpp
@@ -307,7 +307,7 @@ void CUsersTabUsers::onEditUser( enumEditUser enOption )
 
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
 
@@ -316,7 +316,7 @@ void CUsersTabUsers::onEditUser( enumEditUser enOption )
 		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
 		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
 
@@ -406,7 +406,7 @@ void CUsersTabUsers::onGetUsersList()
 
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
 
@@ -415,7 +415,7 @@ void CUsersTabUsers::onGetUsersList()
 		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
 		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
 

--- a/OdbcJdbcSetup/UsersTabUsers.cpp
+++ b/OdbcJdbcSetup/UsersTabUsers.cpp
@@ -307,14 +307,22 @@ void CUsersTabUsers::onEditUser( enumEditUser enOption )
 
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
 
 		char buffer[1024];
-		SQLException &exception = (SQLException&)ex;
-		JString text = exception.getText();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", exception.getSqlcode(), exception.getFbcode(), (const char*)text );
+		JString text = ex.getText();
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
+		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+	}
+	catch (std::exception &ex)
+	{
+		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
+
+		char buffer[1024];
+		JString text = ex.what();
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
 		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
 	}
 
@@ -398,14 +406,22 @@ void CUsersTabUsers::onGetUsersList()
 
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
 		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
 
 		char buffer[1024];
-		SQLException &exception = (SQLException&)ex;
-		JString text = exception.getText();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", exception.getSqlcode(), exception.getFbcode(), (const char*)text );
+		JString text = ex.getText();
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
+		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+	}
+	catch (std::exception &ex)
+	{
+		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
+
+		char buffer[1024];
+		JString text = ex.what();
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
 		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
 	}
 

--- a/OdbcJdbcSetup/UsersTabUsers.cpp
+++ b/OdbcJdbcSetup/UsersTabUsers.cpp
@@ -267,6 +267,15 @@ void CUsersTabUsers::onEditUser( enumEditUser enOption )
 	int lengthOut;
 	char bufferOut[1024];
 
+	auto handle_error = [&](const char* text, int sqlcode = 0, int fbcode = 0)
+	{
+		EnableWindow(GetDlgItem(hDlg, IDC_BUTTON_GET_INFO), TRUE);
+
+		char buffer[1024];
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", sqlcode, fbcode, text);
+		MessageBox(NULL, buffer, TEXT("Error!"), MB_ICONERROR | MB_OK);
+	};
+
 	try
 	{
 
@@ -309,21 +318,11 @@ void CUsersTabUsers::onEditUser( enumEditUser enOption )
 	}
 	catch (const SQLException &ex)
 	{
-		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
-
-		char buffer[1024];
-		JString text = ex.getText();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
-		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+		handle_error(ex.getText(), ex.getSqlcode(), ex.getFbcode());
 	}
 	catch (const std::exception &ex)
 	{
-		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
-
-		char buffer[1024];
-		JString text = ex.what();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
-		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+		handle_error(ex.what());
 	}
 
 	services.closeService();
@@ -348,6 +347,15 @@ void CUsersTabUsers::onGetUsersList()
 		delete[] bufferOut;
 		return;
 	}
+
+	auto handle_error = [&](const char* text, int sqlcode = 0, int fbcode = 0)
+	{
+		EnableWindow(GetDlgItem(hDlg, IDC_BUTTON_GET_INFO), TRUE);
+
+		char buffer[1024];
+		sprintf(buffer, "sqlcode %d, fbcode %d - %s", sqlcode, fbcode, text);
+		MessageBox(NULL, buffer, TEXT("Error!"), MB_ICONERROR | MB_OK);
+	};
 
 	try
 	{
@@ -408,21 +416,11 @@ void CUsersTabUsers::onGetUsersList()
 	}
 	catch (const SQLException &ex)
 	{
-		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
-
-		char buffer[1024];
-		JString text = ex.getText();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", ex.getSqlcode(), ex.getFbcode(), (const char*)text );
-		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+		handle_error(ex.getText(), ex.getSqlcode(), ex.getFbcode());
 	}
 	catch (const std::exception &ex)
 	{
-		EnableWindow( GetDlgItem( hDlg, IDC_BUTTON_GET_INFO ), TRUE );
-
-		char buffer[1024];
-		JString text = ex.what();
-		sprintf(buffer, "sqlcode %d, fbcode %d - %s", 0, 0, (const char*)text );
-		MessageBox( NULL, buffer, TEXT( "Error!" ), MB_ICONERROR | MB_OK );
+		handle_error(ex.what());
 	}
 
 	delete[] bufferOut;

--- a/OdbcObject.cpp
+++ b/OdbcObject.cpp
@@ -263,6 +263,15 @@ OdbcError* OdbcObject::postError(const char * sqlState, SQLException &exception)
 	return postError( new OdbcError( exception.getSqlcode(), exception.getFbcode(), sqlState, exception.getText() ) );
 }
 
+// Companion overload for std::exception. C++ catch ordering means a call
+// site that catches SQLException first will dispatch the SQLException
+// overload above and only reach this one for non-SQLException objects, so
+// we can use what() directly without any runtime type check.
+OdbcError* OdbcObject::postError(const char * sqlState, std::exception &ex)
+{
+	return postError( new OdbcError( 0, 0, sqlState, ex.what() ) );
+}
+
 const char * OdbcObject::getString(char * * temp, const UCHAR * string, int length, const char *defaultValue)
 {
 	if (!string)

--- a/OdbcObject.cpp
+++ b/OdbcObject.cpp
@@ -258,7 +258,7 @@ void OdbcObject::clearErrors()
 }
 
 
-OdbcError* OdbcObject::postError(const char * sqlState, SQLException &exception)
+OdbcError* OdbcObject::postError(const char * sqlState, const SQLException &exception)
 {
 	return postError( new OdbcError( exception.getSqlcode(), exception.getFbcode(), sqlState, exception.getText() ) );
 }
@@ -267,7 +267,7 @@ OdbcError* OdbcObject::postError(const char * sqlState, SQLException &exception)
 // site that catches SQLException first will dispatch the SQLException
 // overload above and only reach this one for non-SQLException objects, so
 // we can use what() directly without any runtime type check.
-OdbcError* OdbcObject::postError(const char * sqlState, std::exception &ex)
+OdbcError* OdbcObject::postError(const char * sqlState, const std::exception &ex)
 {
 	return postError( new OdbcError( 0, 0, sqlState, ex.what() ) );
 }

--- a/OdbcObject.h
+++ b/OdbcObject.h
@@ -57,8 +57,8 @@ public:
 	SQLRETURN sqlGetDiagRec (int handleType, int recNumber, SQLCHAR*sqlState,SQLINTEGER*nativeErrorPtr,SQLCHAR*messageText,int bufferLength,SQLSMALLINT*textLengthPtr);
 	OdbcError* postError (const char *state, JString msg);
 	const char * getString (char **temp, const UCHAR *string, int length, const char *defaultValue);
-	OdbcError* postError (const char *sqlState, SQLException &exception);
-	OdbcError* postError (const char *sqlState, std::exception &ex);
+	OdbcError* postError (const char *sqlState, const SQLException &exception);
+	OdbcError* postError (const char *sqlState, const std::exception &ex);
 	void operator <<(OdbcObject * obj);
 	void clearErrors();
 	OdbcError* postError (OdbcError *error);

--- a/OdbcObject.h
+++ b/OdbcObject.h
@@ -58,6 +58,7 @@ public:
 	OdbcError* postError (const char *state, JString msg);
 	const char * getString (char **temp, const UCHAR *string, int length, const char *defaultValue);
 	OdbcError* postError (const char *sqlState, SQLException &exception);
+	OdbcError* postError (const char *sqlState, std::exception &ex);
 	void operator <<(OdbcObject * obj);
 	void clearErrors();
 	OdbcError* postError (OdbcError *error);

--- a/OdbcStatement.cpp
+++ b/OdbcStatement.cpp
@@ -158,8 +158,8 @@ void TraceOutput(char * msg, intptr_t val)
 	OutputDebugString(buf);
 }
 
-//	Bound Address + Binding Offset + ((Row Number – 1) x Element Size)
-//	*ptr = binding->pointer + bindOffsetPtr + ((1 – 1) * rowBindType); // <-- for single row
+//	Bound Address + Binding Offset + ((Row Number ï¿½ 1) x Element Size)
+//	*ptr = binding->pointer + bindOffsetPtr + ((1 ï¿½ 1) * rowBindType); // <-- for single row
 #define GETBOUNDADDRESS(binding)	( (uintptr_t)binding->dataPtr + ( applicationParamDescriptor->headBindType ? (uintptr_t)bindOffsetPtr : 0 ) );
 
 //////////////////////////////////////////////////////////////////////
@@ -302,10 +302,14 @@ SQLRETURN OdbcStatement::sqlTables(SQLCHAR * catalog, int catLength,
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getTables (cat, scheme, tbl, numberTypes, typeVector));
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -329,10 +333,14 @@ SQLRETURN OdbcStatement::sqlTablePrivileges(SQLCHAR * catalog, int catLength,
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getTablePrivileges (cat, scheme, tbl));
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -358,10 +366,14 @@ SQLRETURN OdbcStatement::sqlColumnPrivileges(SQLCHAR * catalog, int catLength,
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getColumnPrivileges (cat, scheme, tbl, col));
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -479,10 +491,14 @@ SQLRETURN OdbcStatement::sqlPrepare(SQLCHAR * sql, int sqlLength)
 			}
 		}
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -710,10 +726,14 @@ SQLRETURN OdbcStatement::sqlBindCol(int column, int targetType, SQLPOINTER targe
 			bulkInsert = NULL;
 		}
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -818,11 +838,17 @@ SQLRETURN OdbcStatement::fetchData()
 			return SQL_NO_DATA;
 		}
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
 		bindOffsetPtr = bindOffsetPtrSave;
-		OdbcError *error = postError ("HY000", exception);
+		OdbcError *error = postError ("HY000", ex);
+		error->setRowNumber (rowNumber);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		bindOffsetPtr = bindOffsetPtrSave;
+		OdbcError *error = postError ("HY000", ex);
 		error->setRowNumber (rowNumber);
 		return SQL_ERROR;
 	}
@@ -1406,7 +1432,7 @@ SQLRETURN OdbcStatement::sqlBulkOperations( int operation )
 			return sqlReturn( SQL_ERROR, "IM001", (const char*)"Driver does not support this function" );
 		}
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
 		if ( bulkInsert )
 		{
@@ -1416,8 +1442,20 @@ SQLRETURN OdbcStatement::sqlBulkOperations( int operation )
 			bulkInsert->statement->rollbackLocal();
 		}
 
-		SQLException &exception = (SQLException&)ex;
-		postError( "HY000", exception );
+		postError( "HY000", ex );
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		if ( bulkInsert )
+		{
+			if ( bulkInsert->infoPosted )
+				*this << bulkInsert;
+
+			bulkInsert->statement->rollbackLocal();
+		}
+
+		postError( "HY000", ex );
 		return SQL_ERROR;
 	}
 
@@ -1522,10 +1560,14 @@ SQLRETURN OdbcStatement::sqlColumns(SQLCHAR * catalog, int catLength, SQLCHAR * 
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getColumns (cat, scheme, tbl, col));
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -1564,10 +1606,14 @@ SQLRETURN OdbcStatement::sqlFreeStmt(int option)
 			break;
 		}
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -1627,10 +1673,14 @@ SQLRETURN OdbcStatement::sqlStatistics(SQLCHAR * catalog, int catLength,
 										unique == SQL_INDEX_UNIQUE, 
 										reservedSic == SQL_QUICK));
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -1652,10 +1702,14 @@ SQLRETURN OdbcStatement::sqlPrimaryKeys(SQLCHAR * catalog, int catLength, SQLCHA
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getPrimaryKeys (cat, scheme, tbl));
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -1685,10 +1739,14 @@ SQLRETURN OdbcStatement::sqlForeignKeys (SQLCHAR * pkCatalog, int pkCatLength,
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getCrossReference (pkCat, pkScheme,pkTbl,fkCat,fkScheme,fkTbl));
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -1715,10 +1773,14 @@ SQLRETURN OdbcStatement::sqlNumParams(SWORD * params)
 			if( params )
 				*params = statement->getNumParams();
 		}
-		catch ( std::exception &ex )
+		catch (SQLException &ex)
 		{
-			SQLException &exception = (SQLException&)ex;
-			postError ("HY000", exception);
+			postError ("HY000", ex);
+			return SQL_ERROR;
+		}
+		catch (std::exception &ex)
+		{
+			postError ("HY000", ex);
 			return SQL_ERROR;
 		}
 	else if( params )
@@ -1766,10 +1828,14 @@ SQLRETURN OdbcStatement::sqlDescribeCol(int col,
 		OutputDebugString (tempDebugStr);
 #endif
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -1897,10 +1963,14 @@ SQLRETURN OdbcStatement::sqlGetData(int column, int cType, PTR pointer, SQLLEN b
 				return SQL_SUCCESS_WITH_INFO;
 			}
 		}
-		catch ( std::exception &ex )
+		catch (SQLException &ex)
 		{
-			SQLException &exception = (SQLException&)ex;
-			postError ("HY000", exception);
+			postError ("HY000", ex);
+			return SQL_ERROR;
+		}
+		catch (std::exception &ex)
+		{
+			postError ("HY000", ex);
 			return SQL_ERROR;
 		}
 	}
@@ -1920,10 +1990,14 @@ SQLRETURN OdbcStatement::sqlExecute()
 		parameterNeedData = 0;
 		retcode = (this->*execute)();
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		retcode = SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		retcode = SQL_ERROR;
 	}
 
@@ -1944,10 +2018,14 @@ SQLRETURN OdbcStatement::sqlExecDirect(SQLCHAR * sql, int sqlLength)
 		parameterNeedData = 0;
 		retcode = (this->*execute)();
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -2037,10 +2115,14 @@ SQLRETURN OdbcStatement::sqlDescribeParam(int parameter, SWORD * sqlType, SQLULE
 		if (nullable)
 			*nullable = (metaData->isNullable (parameter)) ? SQL_NULLABLE : SQL_NO_NULLS;
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -2290,10 +2372,14 @@ SQLRETURN OdbcStatement::sqlBindParameter(int parameter, int type, int cType,
 
 		registrationOutParameter = false;
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -2306,10 +2392,14 @@ SQLRETURN OdbcStatement::sqlCancel()
 	{
 		cancel = true;
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -2331,10 +2421,14 @@ SQLRETURN OdbcStatement::sqlProcedures(SQLCHAR * catalog, int catLength, SQLCHAR
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getProcedures (cat, scheme, procedures));
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -2357,10 +2451,14 @@ SQLRETURN OdbcStatement::sqlProcedureColumns(SQLCHAR * catalog, int catLength, S
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getProcedureColumns (cat, scheme, procedures, columns));
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -2384,10 +2482,14 @@ SQLRETURN OdbcStatement::sqlSetCursorName(SQLCHAR * name, int nameLength)
 			setPreCursorName = false;
 		}
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -2403,10 +2505,14 @@ SQLRETURN OdbcStatement::sqlCloseCursor()
 		setPreCursorName = false;
 		releaseResultSet();
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -2560,10 +2666,14 @@ SQLRETURN OdbcStatement::sqlGetStmtAttr(int attribute, SQLPOINTER ptr, int buffe
 		if (lengthPtr)
 			*lengthPtr = sizeof (intptr_t);
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -2577,10 +2687,14 @@ SQLRETURN OdbcStatement::sqlGetCursorName(SQLCHAR *name, int bufferLength, SQLSM
 	{
 		returnStringInfo (name, bufferLength, nameLength, cursorName);
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 	return sqlSuccess();
@@ -2981,10 +3095,14 @@ SQLRETURN OdbcStatement::executeCommit()
 			statement->commitLocal();
 			return SQL_SUCCESS;
 		}
-		catch ( std::exception &ex )
+		catch (SQLException &ex)
 		{
-			SQLException &exception = (SQLException&)ex;
-			postError( "S1000", exception );
+			postError( "S1000", ex );
+			return SQL_ERROR;
+		}
+		catch (std::exception &ex)
+		{
+			postError( "S1000", ex );
 			return SQL_ERROR;
 		}
 	}
@@ -3003,10 +3121,14 @@ SQLRETURN OdbcStatement::executeRollback()
 			statement->rollbackLocal();
 			return SQL_SUCCESS;
 		}
-		catch ( std::exception &ex )
+		catch (SQLException &ex)
 		{
-			SQLException &exception = (SQLException&)ex;
-			postError( "S1000", exception );
+			postError( "S1000", ex );
+			return SQL_ERROR;
+		}
+		catch (std::exception &ex)
+		{
+			postError( "S1000", ex );
 			return SQL_ERROR;
 		}
 	}
@@ -3034,10 +3156,14 @@ SQLRETURN OdbcStatement::sqlGetTypeInfo(int dataType)
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getTypeInfo (dataType), false);
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -3109,10 +3235,14 @@ SQLRETURN OdbcStatement::sqlParamData(SQLPOINTER *ptr)
 			*(uintptr_t*)ptr = GETBOUNDADDRESS(binding);
 		}
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		retcode = SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		retcode = SQL_ERROR;
 	}
 
@@ -3479,10 +3609,14 @@ SQLRETURN OdbcStatement::sqlSetStmtAttr(int attribute, SQLPOINTER ptr, int lengt
 			return sqlReturn (SQL_ERROR, "HYC00", "Optional feature not implemented");
 		}
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -3511,10 +3645,14 @@ SQLRETURN OdbcStatement::sqlRowCount(SQLLEN *rowCount)
 				*rowCount = -1;
 		}
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -3651,10 +3789,14 @@ SQLRETURN OdbcStatement::sqlColAttribute( int column, int fieldId, SQLPOINTER at
 			}
 		}
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 
@@ -3705,10 +3847,14 @@ SQLRETURN OdbcStatement::sqlSpecialColumns(unsigned short rowId, SQLCHAR * catal
 			eof = true;
 		}
 	}
-	catch ( std::exception &ex )
+	catch (SQLException &ex)
 	{
-		SQLException &exception = (SQLException&)ex;
-		postError ("HY000", exception);
+		postError ("HY000", ex);
+		return SQL_ERROR;
+	}
+	catch (std::exception &ex)
+	{
+		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
 

--- a/OdbcStatement.cpp
+++ b/OdbcStatement.cpp
@@ -131,6 +131,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include "IscDbc/Connection.h"
 #include "IscDbc/SQLException.h"
 #include "OdbcEnv.h"
@@ -151,15 +152,15 @@ namespace OdbcJdbcLibrary {
 
 using namespace IscDbcLibrary;
 
-void TraceOutput(char * msg, intptr_t val)
+static void TraceOutput(char * msg, intptr_t val)
 {
 	char buf[80];
-	sprintf( buf, "\t%s = %ld : %p\n", msg, val, (void*)val );
+	sprintf( buf, "\t%s = %" PRIu64 " : %p\n", msg, val, (void*)val );
 	OutputDebugString(buf);
 }
 
-//	Bound Address + Binding Offset + ((Row Number � 1) x Element Size)
-//	*ptr = binding->pointer + bindOffsetPtr + ((1 � 1) * rowBindType); // <-- for single row
+//	Bound Address + Binding Offset + ((Row Number - 1) x Element Size)
+//	*ptr = binding->pointer + bindOffsetPtr + ((1 - 1) * rowBindType); // <-- for single row
 #define GETBOUNDADDRESS(binding)	( (uintptr_t)binding->dataPtr + ( applicationParamDescriptor->headBindType ? (uintptr_t)bindOffsetPtr : 0 ) );
 
 //////////////////////////////////////////////////////////////////////
@@ -760,6 +761,14 @@ SQLRETURN OdbcStatement::fetchData()
 	SQLLEN *&bindOffsetPtr = applicationRowDescriptor->headBindOffsetPtr;
 	SQLLEN *bindOffsetPtrSave = bindOffsetPtr;
 
+	auto handle_error = [&](const char* state, auto& ex) -> SQLRETURN
+	{
+		bindOffsetPtr = bindOffsetPtrSave;
+		OdbcError* error = postError(state, ex);
+		error->setRowNumber(rowNumber);
+		return SQL_ERROR;
+	};
+
 	try
 	{
 		int nRow = 0;
@@ -840,17 +849,11 @@ SQLRETURN OdbcStatement::fetchData()
 	}
 	catch (const SQLException &ex)
 	{
-		bindOffsetPtr = bindOffsetPtrSave;
-		OdbcError *error = postError ("HY000", ex);
-		error->setRowNumber (rowNumber);
-		return SQL_ERROR;
+		return handle_error("HY000", ex);
 	}
 	catch (const std::exception &ex)
 	{
-		bindOffsetPtr = bindOffsetPtrSave;
-		OdbcError *error = postError ("HY000", ex);
-		error->setRowNumber (rowNumber);
-		return SQL_ERROR;
+		return handle_error("HY000", ex);
 	}
 
 	return sqlSuccess();
@@ -1324,6 +1327,20 @@ SQLRETURN OdbcStatement::sqlBulkOperations( int operation )
 	if ( !resultSet )
 		return sqlReturn( SQL_ERROR, "24000", "Invalid cursor state" );
 
+	auto handle_error = [&](const char* state, auto& ex) -> SQLRETURN
+	{
+		if (bulkInsert)
+		{
+			if (bulkInsert->infoPosted)
+				*this << bulkInsert;
+
+			bulkInsert->statement->rollbackLocal();
+		}
+
+		postError(state, ex);
+		return SQL_ERROR;
+	};
+
 	try
 	{
 		switch ( operation )
@@ -1434,29 +1451,11 @@ SQLRETURN OdbcStatement::sqlBulkOperations( int operation )
 	}
 	catch (const SQLException &ex)
 	{
-		if ( bulkInsert )
-		{
-			if ( bulkInsert->infoPosted )
-				*this << bulkInsert;
-
-			bulkInsert->statement->rollbackLocal();
-		}
-
-		postError( "HY000", ex );
-		return SQL_ERROR;
+		return handle_error("HY000", ex);
 	}
 	catch (const std::exception &ex)
 	{
-		if ( bulkInsert )
-		{
-			if ( bulkInsert->infoPosted )
-				*this << bulkInsert;
-
-			bulkInsert->statement->rollbackLocal();
-		}
-
-		postError( "HY000", ex );
-		return SQL_ERROR;
+		return handle_error("HY000", ex);
 	}
 
 	return sqlSuccess();

--- a/OdbcStatement.cpp
+++ b/OdbcStatement.cpp
@@ -302,12 +302,12 @@ SQLRETURN OdbcStatement::sqlTables(SQLCHAR * catalog, int catLength,
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getTables (cat, scheme, tbl, numberTypes, typeVector));
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -333,12 +333,12 @@ SQLRETURN OdbcStatement::sqlTablePrivileges(SQLCHAR * catalog, int catLength,
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getTablePrivileges (cat, scheme, tbl));
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -366,12 +366,12 @@ SQLRETURN OdbcStatement::sqlColumnPrivileges(SQLCHAR * catalog, int catLength,
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getColumnPrivileges (cat, scheme, tbl, col));
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -491,12 +491,12 @@ SQLRETURN OdbcStatement::sqlPrepare(SQLCHAR * sql, int sqlLength)
 			}
 		}
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -726,12 +726,12 @@ SQLRETURN OdbcStatement::sqlBindCol(int column, int targetType, SQLPOINTER targe
 			bulkInsert = NULL;
 		}
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -838,14 +838,14 @@ SQLRETURN OdbcStatement::fetchData()
 			return SQL_NO_DATA;
 		}
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		bindOffsetPtr = bindOffsetPtrSave;
 		OdbcError *error = postError ("HY000", ex);
 		error->setRowNumber (rowNumber);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		bindOffsetPtr = bindOffsetPtrSave;
 		OdbcError *error = postError ("HY000", ex);
@@ -1432,7 +1432,7 @@ SQLRETURN OdbcStatement::sqlBulkOperations( int operation )
 			return sqlReturn( SQL_ERROR, "IM001", (const char*)"Driver does not support this function" );
 		}
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		if ( bulkInsert )
 		{
@@ -1445,7 +1445,7 @@ SQLRETURN OdbcStatement::sqlBulkOperations( int operation )
 		postError( "HY000", ex );
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		if ( bulkInsert )
 		{
@@ -1560,12 +1560,12 @@ SQLRETURN OdbcStatement::sqlColumns(SQLCHAR * catalog, int catLength, SQLCHAR * 
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getColumns (cat, scheme, tbl, col));
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -1606,12 +1606,12 @@ SQLRETURN OdbcStatement::sqlFreeStmt(int option)
 			break;
 		}
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -1673,12 +1673,12 @@ SQLRETURN OdbcStatement::sqlStatistics(SQLCHAR * catalog, int catLength,
 										unique == SQL_INDEX_UNIQUE, 
 										reservedSic == SQL_QUICK));
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -1702,12 +1702,12 @@ SQLRETURN OdbcStatement::sqlPrimaryKeys(SQLCHAR * catalog, int catLength, SQLCHA
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getPrimaryKeys (cat, scheme, tbl));
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -1739,12 +1739,12 @@ SQLRETURN OdbcStatement::sqlForeignKeys (SQLCHAR * pkCatalog, int pkCatLength,
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getCrossReference (pkCat, pkScheme,pkTbl,fkCat,fkScheme,fkTbl));
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -1773,12 +1773,12 @@ SQLRETURN OdbcStatement::sqlNumParams(SWORD * params)
 			if( params )
 				*params = statement->getNumParams();
 		}
-		catch (SQLException &ex)
+		catch (const SQLException &ex)
 		{
 			postError ("HY000", ex);
 			return SQL_ERROR;
 		}
-		catch (std::exception &ex)
+		catch (const std::exception &ex)
 		{
 			postError ("HY000", ex);
 			return SQL_ERROR;
@@ -1828,12 +1828,12 @@ SQLRETURN OdbcStatement::sqlDescribeCol(int col,
 		OutputDebugString (tempDebugStr);
 #endif
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -1963,12 +1963,12 @@ SQLRETURN OdbcStatement::sqlGetData(int column, int cType, PTR pointer, SQLLEN b
 				return SQL_SUCCESS_WITH_INFO;
 			}
 		}
-		catch (SQLException &ex)
+		catch (const SQLException &ex)
 		{
 			postError ("HY000", ex);
 			return SQL_ERROR;
 		}
-		catch (std::exception &ex)
+		catch (const std::exception &ex)
 		{
 			postError ("HY000", ex);
 			return SQL_ERROR;
@@ -1990,12 +1990,12 @@ SQLRETURN OdbcStatement::sqlExecute()
 		parameterNeedData = 0;
 		retcode = (this->*execute)();
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		retcode = SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		retcode = SQL_ERROR;
@@ -2018,12 +2018,12 @@ SQLRETURN OdbcStatement::sqlExecDirect(SQLCHAR * sql, int sqlLength)
 		parameterNeedData = 0;
 		retcode = (this->*execute)();
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -2115,12 +2115,12 @@ SQLRETURN OdbcStatement::sqlDescribeParam(int parameter, SWORD * sqlType, SQLULE
 		if (nullable)
 			*nullable = (metaData->isNullable (parameter)) ? SQL_NULLABLE : SQL_NO_NULLS;
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -2372,12 +2372,12 @@ SQLRETURN OdbcStatement::sqlBindParameter(int parameter, int type, int cType,
 
 		registrationOutParameter = false;
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -2392,12 +2392,12 @@ SQLRETURN OdbcStatement::sqlCancel()
 	{
 		cancel = true;
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -2421,12 +2421,12 @@ SQLRETURN OdbcStatement::sqlProcedures(SQLCHAR * catalog, int catLength, SQLCHAR
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getProcedures (cat, scheme, procedures));
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -2451,12 +2451,12 @@ SQLRETURN OdbcStatement::sqlProcedureColumns(SQLCHAR * catalog, int catLength, S
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getProcedureColumns (cat, scheme, procedures, columns));
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -2482,12 +2482,12 @@ SQLRETURN OdbcStatement::sqlSetCursorName(SQLCHAR * name, int nameLength)
 			setPreCursorName = false;
 		}
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -2505,12 +2505,12 @@ SQLRETURN OdbcStatement::sqlCloseCursor()
 		setPreCursorName = false;
 		releaseResultSet();
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -2666,12 +2666,12 @@ SQLRETURN OdbcStatement::sqlGetStmtAttr(int attribute, SQLPOINTER ptr, int buffe
 		if (lengthPtr)
 			*lengthPtr = sizeof (intptr_t);
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -2687,12 +2687,12 @@ SQLRETURN OdbcStatement::sqlGetCursorName(SQLCHAR *name, int bufferLength, SQLSM
 	{
 		returnStringInfo (name, bufferLength, nameLength, cursorName);
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -3095,12 +3095,12 @@ SQLRETURN OdbcStatement::executeCommit()
 			statement->commitLocal();
 			return SQL_SUCCESS;
 		}
-		catch (SQLException &ex)
+		catch (const SQLException &ex)
 		{
 			postError( "S1000", ex );
 			return SQL_ERROR;
 		}
-		catch (std::exception &ex)
+		catch (const std::exception &ex)
 		{
 			postError( "S1000", ex );
 			return SQL_ERROR;
@@ -3121,12 +3121,12 @@ SQLRETURN OdbcStatement::executeRollback()
 			statement->rollbackLocal();
 			return SQL_SUCCESS;
 		}
-		catch (SQLException &ex)
+		catch (const SQLException &ex)
 		{
 			postError( "S1000", ex );
 			return SQL_ERROR;
 		}
-		catch (std::exception &ex)
+		catch (const std::exception &ex)
 		{
 			postError( "S1000", ex );
 			return SQL_ERROR;
@@ -3156,12 +3156,12 @@ SQLRETURN OdbcStatement::sqlGetTypeInfo(int dataType)
 		DatabaseMetaData *metaData = connection->getMetaData();
 		setResultSet (metaData->getTypeInfo (dataType), false);
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -3235,12 +3235,12 @@ SQLRETURN OdbcStatement::sqlParamData(SQLPOINTER *ptr)
 			*(uintptr_t*)ptr = GETBOUNDADDRESS(binding);
 		}
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		retcode = SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		retcode = SQL_ERROR;
@@ -3609,12 +3609,12 @@ SQLRETURN OdbcStatement::sqlSetStmtAttr(int attribute, SQLPOINTER ptr, int lengt
 			return sqlReturn (SQL_ERROR, "HYC00", "Optional feature not implemented");
 		}
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -3645,12 +3645,12 @@ SQLRETURN OdbcStatement::sqlRowCount(SQLLEN *rowCount)
 				*rowCount = -1;
 		}
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -3789,12 +3789,12 @@ SQLRETURN OdbcStatement::sqlColAttribute( int column, int fieldId, SQLPOINTER at
 			}
 		}
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
@@ -3847,12 +3847,12 @@ SQLRETURN OdbcStatement::sqlSpecialColumns(unsigned short rowId, SQLCHAR * catal
 			eof = true;
 		}
 	}
-	catch (SQLException &ex)
+	catch (const SQLException &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;
 	}
-	catch (std::exception &ex)
+	catch (const std::exception &ex)
 	{
 		postError ("HY000", ex);
 		return SQL_ERROR;

--- a/tests/test_connect_options.cpp
+++ b/tests/test_connect_options.cpp
@@ -3,6 +3,7 @@
 // Tests SQLConnect, SQLDriverConnect, attribute persistence, and transaction behavior.
 
 #include "test_helpers.h"
+#include <cctype>
 #include <thread>
 #include <chrono>
 
@@ -708,4 +709,130 @@ TEST_F(ConnectionResetTest, ResetResetsQueryTimeout) {
     ASSERT_TRUE(SQL_SUCCEEDED(ret));
     EXPECT_EQ(timeout, 0u)
         << "Query timeout should be 0 after connection reset";
+}
+
+// ===== Negative SQLDriverConnect tests =====
+//
+// When SQLDriverConnect fails the driver must populate a well-formed diagnostic
+// record. A failed call that returns an empty SQLSTATE, a wild native code or
+// a message whose strlen does not match the reported length leaves callers
+// with no way to recover or branch on the error.
+
+namespace {
+
+// Replace the value of a single connection-string key (case-insensitive). If
+// the key isn't present the original string is returned unchanged.
+std::string ReplaceConnKey(const std::string &conn,
+                           const std::string &key,
+                           const std::string &newValue) {
+    std::string out;
+    size_t pos = 0;
+    while (pos < conn.size()) {
+        size_t end = conn.find(';', pos);
+        if (end == std::string::npos) end = conn.size();
+        std::string token = conn.substr(pos, end - pos);
+        size_t eq = token.find('=');
+        std::string tokKey = (eq != std::string::npos) ? token.substr(0, eq) : token;
+        std::string tokKeyLower = tokKey;
+        std::string keyLower = key;
+        for (auto &c : tokKeyLower) c = (char)tolower((unsigned char)c);
+        for (auto &c : keyLower)    c = (char)tolower((unsigned char)c);
+        if (tokKeyLower == keyLower)
+            out += tokKey + "=" + newValue;
+        else
+            out += token;
+        if (end < conn.size()) out += ';';
+        pos = end + 1;
+    }
+    return out;
+}
+
+} // namespace
+
+// Failed login (wrong password) must produce a well-formed diagnostic record.
+// Note: Firebird in embedded/local-trusted-auth mode (which CI uses) does not
+// check the password, so this test skips itself when the connect unexpectedly
+// succeeds.
+TEST_F(ConnectOptionsTest, BadPasswordReturnsValidDiagRec) {
+    AllocEnvAndDbc();
+
+    std::string badConn = ReplaceConnKey(GetConnectionString(),
+                                         "PWD", "invalid-password-xyz");
+
+    SQLCHAR outStr[1024] = {};
+    SQLSMALLINT outLen = 0;
+    SQLRETURN rc = SQLDriverConnect(hDbc, NULL,
+        (SQLCHAR*)badConn.c_str(), SQL_NTS,
+        outStr, sizeof(outStr), &outLen,
+        SQL_DRIVER_NOPROMPT);
+    if (SQL_SUCCEEDED(rc)) {
+        GTEST_SKIP() << "Connect succeeded despite invalid password; the "
+                        "Firebird server is using embedded or trusted "
+                        "authentication and won't exercise the failure path.";
+    }
+
+    SQLCHAR sqlState[6] = {};
+    SQLINTEGER native = 0;
+    SQLCHAR msg[1024] = {};
+    SQLSMALLINT msgLen = 0;
+    SQLRETURN drc = SQLGetDiagRec(SQL_HANDLE_DBC, hDbc, 1, sqlState, &native,
+                                  msg, sizeof(msg), &msgLen);
+    ASSERT_EQ(drc, SQL_SUCCESS)
+        << "SQLGetDiagRec must return a record after SQLDriverConnect failure";
+
+    EXPECT_EQ(strlen((char*)sqlState), 5u)
+        << "SQLSTATE must be exactly 5 chars, got '"
+        << (char*)sqlState << "' (len=" << strlen((char*)sqlState) << ")";
+
+    EXPECT_EQ((size_t)msgLen, strlen((char*)msg))
+        << "Reported message length (" << msgLen
+        << ") must match strlen of returned message ("
+        << strlen((char*)msg) << "); message='" << (char*)msg << "'";
+
+    EXPECT_GT(strlen((char*)msg), 1u)
+        << "Message must contain more than a single byte; got '"
+        << (char*)msg << "'";
+}
+
+// Failed connect to a nonexistent database must also produce a well-formed
+// diagnostic record.
+TEST_F(ConnectOptionsTest, NonexistentDatabaseReturnsValidDiagRec) {
+    AllocEnvAndDbc();
+
+    // Build a connection string with the same Driver but pointing at a path
+    // that cannot exist. Try both spellings: Database= and Dbname=.
+    std::string bogus = "/nonexistent/path/no-such-database.fdb";
+    std::string badConn = ReplaceConnKey(GetConnectionString(), "Database", bogus);
+    badConn = ReplaceConnKey(badConn, "Dbname", bogus);
+
+    SQLCHAR outStr[1024] = {};
+    SQLSMALLINT outLen = 0;
+    SQLRETURN rc = SQLDriverConnect(hDbc, NULL,
+        (SQLCHAR*)badConn.c_str(), SQL_NTS,
+        outStr, sizeof(outStr), &outLen,
+        SQL_DRIVER_NOPROMPT);
+    ASSERT_FALSE(SQL_SUCCEEDED(rc))
+        << "Connect to nonexistent database was expected to fail";
+
+    SQLCHAR sqlState[6] = {};
+    SQLINTEGER native = 0;
+    SQLCHAR msg[1024] = {};
+    SQLSMALLINT msgLen = 0;
+    SQLRETURN drc = SQLGetDiagRec(SQL_HANDLE_DBC, hDbc, 1, sqlState, &native,
+                                  msg, sizeof(msg), &msgLen);
+    ASSERT_EQ(drc, SQL_SUCCESS)
+        << "SQLGetDiagRec must return a record after SQLDriverConnect failure";
+
+    EXPECT_EQ(strlen((char*)sqlState), 5u)
+        << "SQLSTATE must be exactly 5 chars, got '"
+        << (char*)sqlState << "' (len=" << strlen((char*)sqlState) << ")";
+
+    EXPECT_EQ((size_t)msgLen, strlen((char*)msg))
+        << "Reported message length (" << msgLen
+        << ") must match strlen of returned message ("
+        << strlen((char*)msg) << "); message='" << (char*)msg << "'";
+
+    EXPECT_GT(strlen((char*)msg), 1u)
+        << "Message must contain more than a single byte; got '"
+        << (char*)msg << "'";
 }


### PR DESCRIPTION
## Summary

Every catch block that handled `std::exception` followed the same broken pattern:

```cpp
catch ( std::exception &ex ) {
    SQLException &exception = (SQLException&)ex;
    // virtual calls on `exception`...
}
```

The C-style cast is a `reinterpret_cast`. When the caught object was not in fact a `SQLException` (e.g. a `std::bad_alloc`, a raw `FbException` that bypassed the IscDbc rewrap, or anything else that propagated out of the IscDbc layer), the subsequent virtual dispatch through `exception` read through whatever bytes lay where `SQLException`'s vtable pointer would have been. On Linux that produced a diagnostic record with:

- empty `SQLSTATE`,
- a non-deterministic native code (varying every run),
- a one-byte message (`[`) whose reported length disagreed with its `strlen`.

ODBC clients (`unixODBC`'s `isql`, `pyodbc`, Tcl's `tdbc::odbc`, …) cannot recover useful information from such a record, so application-level retry/branch logic on `SQLSTATE` or native code is impossible.

## What this PR does

- Introduces an `ExceptionInfo` helper plus a new `postError(state, std::exception&)` overload in `IscDbc/SQLException.h` / `OdbcObject`. Both route through `dynamic_cast<SQLException*>`, falling back to `std::exception::what()` when the caught object isn't a `SQLException`.
- Converts all 64 occurrences of the broken pattern across `OdbcConnection`, `OdbcStatement`, `OdbcDesc`, `OdbcEnv`, and the Windows `OdbcJdbcSetup` tree to the safe path.
- Adds a NULL guard around `connection->close()` in `OdbcConnection::connect` so a throw inside `createConnection()` (before `connection` is assigned) no longer dereferences NULL during cleanup.
- Adds two regression tests in `tests/test_connect_options.cpp`:
  - `BadPasswordReturnsValidDiagRec` — verifies the diag record after a wrong-password failure (skips itself in embedded/trusted-auth setups that don't reject the password, including CI).
  - `NonexistentDatabaseReturnsValidDiagRec` — verifies the diag record after a connect to a nonexistent database path.

Both tests assert that after `SQLDriverConnect` fails the diag record has a 5-character `SQLSTATE`, a reported message length matching `strlen` of the message, and a message longer than a single byte.

## Verification

CI matrix (all green on the head of this PR):
- Windows x64 / x86 (Win32) / ARM64
- Linux x64 / ARM64
- Linux x64 with Valgrind

Tested against Firebird 5.0.3 and the Firebird master snapshot.

## Test plan
- [x] All existing tests still pass on the full Windows + Linux matrix
- [x] New `NonexistentDatabaseReturnsValidDiagRec` test passes on all platforms
- [x] New `BadPasswordReturnsValidDiagRec` test runs (skips gracefully when the server doesn't reject the bad password)
- [x] `grep -rn '(SQLException&)' *.cpp *.h IscDbc/ OdbcJdbcSetup/` returns no remaining unchecked casts